### PR TITLE
feat: include host app version in System Info

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ That's it! Users can now click the bug button to submit feedback as GitHub Issue
 | Attribute                       | Values                                               | Default               |
 | ------------------------------- | ---------------------------------------------------- | --------------------- |
 | `data-repo`                     | `owner/repo`                                         | **required**          |
+| `data-app-version`              | Host application version (up to 128 characters)      | omitted               |
 | `data-theme`                    | `light`, `dark`, `auto`                              | `auto`                |
 | `data-locale`                   | `de`, `en`, `nl`, `pl` (region subtags accepted)     | `<html lang>` or `en` |
 | `data-position`                 | `bottom-right`, `bottom-left`                        | `bottom-right`        |

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -9,6 +9,7 @@ These attributes control the fundamental behavior of the widget.
 | Attribute | Default | Description |
 |-----------|---------|-------------|
 | `data-repo` | **(required)** | GitHub repository in `owner/repo` format |
+| `data-app-version` | omitted | Host application version shown in System Info (1 to 128 printable characters) |
 | `data-theme` | `"auto"` | Widget theme: `"light"`, `"dark"`, or `"auto"` |
 | `data-locale` | `<html lang>` or `"en"` | UI language: `"de"`, `"en"`, `"nl"`, or `"pl"` |
 | `data-position` | `"bottom-right"` | Button position: `"bottom-right"` or `"bottom-left"` |

--- a/e2e/api.spec.ts
+++ b/e2e/api.spec.ts
@@ -13,6 +13,7 @@ test.describe('Health API', () => {
     const data = await response.json();
     expect(data.status).toBe('ok');
     expect(data.environment).toBe('development');
+    expect(data.capabilities).toEqual({ appVersionMetadata: true });
     expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 

--- a/e2e/local-submissions.spec.ts
+++ b/e2e/local-submissions.spec.ts
@@ -76,9 +76,47 @@ test('local QA fails closed when the submissions helper cannot load', async ({ p
   expect(escapedRequests).toEqual([]);
 });
 
+test('invalid data-app-version warns, omits metadata, and keeps submission available', async ({
+  page,
+}) => {
+  const prohibitedRequests = watchForProhibitedRequests(page);
+  const warnings: string[] = [];
+  page.on('console', message => {
+    if (message.type() === 'warning') warnings.push(message.text());
+  });
+
+  await page.goto(`/test/?localQa=1&appVersion=${'v'.repeat(129)}`);
+  await page.waitForFunction(() => Boolean(window.BugDrop?.registerVariant));
+  const result = await page.evaluate(() => {
+    const handle = window.BugDrop!.registerVariant({
+      id: 'invalid-app-version',
+      presentation: { kind: 'inline' },
+      content: { title: 'Invalid application version' },
+      fields: [{ id: 'answer', type: 'shortText', label: 'Answer', required: true }],
+      issue: { title: 'Invalid application version {{answer}}' },
+    });
+    return handle.submit(
+      { answer: 'still submits' },
+      { submissionId: 'invalid-app-version-submission' }
+    );
+  });
+
+  expect(warnings).toContain(
+    '[BugDrop] Invalid data-app-version. Expected 1 to 128 printable characters.'
+  );
+  const viewer = await page.context().newPage();
+  await viewer.goto(`/test/submissions.html?id=${result.issueNumber}`);
+  const payload = await readRawPayload(viewer);
+  expect(payload.metadata).not.toHaveProperty('appVersion');
+  expect(prohibitedRequests).toEqual([]);
+  await viewer.close();
+});
+
 test('local QA submissions can be created, viewed, edited, and deleted', async ({ page }) => {
   const prohibitedRequests = watchForProhibitedRequests(page);
-  await page.goto('/test/?localQa=1&showName=true&showIssueLink=always');
+  await page.goto(
+    '/test/?localQa=1&showName=true&showIssueLink=always&appVersion=%20v1.2.3%2Bdesktop%20'
+  );
   await expect(page.getByRole('link', { name: 'Local submissions' })).toBeVisible();
 
   await widget(page).locator('.bd-trigger').click();
@@ -105,6 +143,9 @@ test('local QA submissions can be created, viewed, edited, and deleted', async (
   await expect(viewer.getByRole('heading', { name: /Submission #\d+/ })).toBeVisible();
   await expect(viewer.getByLabel('Title')).toHaveValue('Local CRUD submission');
   await expect(viewer.getByText('Local CRUD submission', { exact: true })).toBeVisible();
+  expect(await readRawPayload(viewer)).toMatchObject({
+    metadata: { appVersion: 'v1.2.3+desktop' },
+  });
 
   await viewer.getByLabel('Title').fill('Edited local submission');
   await viewer.getByRole('button', { name: 'Save changes' }).click();
@@ -177,7 +218,7 @@ test('local QA variants submit headlessly and through inline and modal presentat
   page,
 }) => {
   const prohibitedRequests = watchForProhibitedRequests(page);
-  await page.goto('/test/?localQa=1');
+  await page.goto('/test/?localQa=1&appVersion=%20v1.2.3%2Bdesktop%20');
   await page.waitForFunction(() => Boolean(window.BugDrop?.registerVariant));
 
   const headlessResult = await page.evaluate(async () => {
@@ -299,6 +340,9 @@ test('local QA variants submit headlessly and through inline and modal presentat
   await expect(headlessViewer.locator('#raw-payload')).toContainText(
     '"submissionId": "local-headless-submission"'
   );
+  await expect(headlessViewer.locator('#raw-payload')).toContainText(
+    '"appVersion": "v1.2.3+desktop"'
+  );
   expect(prohibitedRequests).toEqual([]);
 });
 
@@ -308,7 +352,7 @@ test('public flows submit and can be inspected through isolated local feedback s
   test.setTimeout(60_000);
   const prohibitedRequests = watchContextHttpRequests(page.context());
   await page.goto(
-    'http://bugdrop.localhost:8787/test/welcome-disabled?localQa=1&showIssueLink=always&font=inherit'
+    'http://bugdrop.localhost:8787/test/welcome-disabled?localQa=1&showIssueLink=always&font=inherit&appVersion=%20v1.2.3%2Bdesktop%20'
   );
   expect(new URL(page.url()).hostname).toBe('bugdrop.localhost');
   expect(new URL(page.url()).pathname).toBe('/test/welcome-disabled');
@@ -394,7 +438,10 @@ test('public flows submit and can be inspected through isolated local feedback s
     screenshot: null,
     attachments: [],
     submitter: { name: 'Local Flow Tester' },
-    metadata: { url: 'http://bugdrop.localhost:8787/test/welcome-disabled' },
+    metadata: {
+      appVersion: 'v1.2.3+desktop',
+      url: 'http://bugdrop.localhost:8787/test/welcome-disabled',
+    },
   });
   expect(defaultPayload.consoleLogs).toEqual(
     expect.arrayContaining([

--- a/public/test/index.html
+++ b/public/test/index.html
@@ -616,6 +616,7 @@
         showEmail: 'showEmail',
         requireEmail: 'requireEmail',
         categoryLabels: 'categoryLabels',
+        appVersion: 'appVersion',
         showIssueLink: 'showIssueLink',
         sendConsoleLogs: 'sendConsoleLogs',
       },

--- a/public/test/welcome-disabled.html
+++ b/public/test/welcome-disabled.html
@@ -12,7 +12,7 @@
   <script>
     window.loadBugDropTestWidget({
       dataset: { theme: 'dark', welcome: 'false' },
-      queryDataset: { font: 'font' },
+      queryDataset: { appVersion: 'appVersion', font: 'font' },
     });
   </script>
 </body>

--- a/src/app-version.ts
+++ b/src/app-version.ts
@@ -5,6 +5,7 @@ export function parseAppVersion(value: unknown): string | undefined {
 
   const normalized = value.trim();
   if (!normalized || normalized.length > MAX_APP_VERSION_CHARS) return undefined;
+  if (/[\p{Cf}\p{Zl}\p{Zp}]/u.test(normalized)) return undefined;
 
   for (const character of normalized) {
     const code = character.charCodeAt(0);

--- a/src/app-version.ts
+++ b/src/app-version.ts
@@ -4,7 +4,7 @@ export function parseAppVersion(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
 
   const normalized = value.trim();
-  if (!normalized || normalized.length > MAX_APP_VERSION_CHARS) return undefined;
+  if (!normalized || Array.from(normalized).length > MAX_APP_VERSION_CHARS) return undefined;
   if (/[\p{Cf}\p{Zl}\p{Zp}]/u.test(normalized)) return undefined;
 
   for (const character of normalized) {

--- a/src/app-version.ts
+++ b/src/app-version.ts
@@ -1,0 +1,15 @@
+export const MAX_APP_VERSION_CHARS = 128;
+
+export function parseAppVersion(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+
+  const normalized = value.trim();
+  if (!normalized || normalized.length > MAX_APP_VERSION_CHARS) return undefined;
+
+  for (const character of normalized) {
+    const code = character.charCodeAt(0);
+    if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) return undefined;
+  }
+
+  return normalized;
+}

--- a/src/app-version.ts
+++ b/src/app-version.ts
@@ -3,14 +3,15 @@ export const MAX_APP_VERSION_CHARS = 128;
 export function parseAppVersion(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
 
-  const normalized = value.trim();
-  if (!normalized || Array.from(normalized).length > MAX_APP_VERSION_CHARS) return undefined;
-  if (/[\p{Cf}\p{Zl}\p{Zp}]/u.test(normalized)) return undefined;
+  if (/[\p{Cf}\p{Cs}\p{Zl}\p{Zp}]/u.test(value)) return undefined;
 
-  for (const character of normalized) {
+  for (const character of value) {
     const code = character.charCodeAt(0);
     if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) return undefined;
   }
+
+  const normalized = value.trim();
+  if (!normalized || Array.from(normalized).length > MAX_APP_VERSION_CHARS) return undefined;
 
   return normalized;
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -20,3 +20,14 @@ export function escapeMarkdownTableCell(value: string): string {
 
   return escaped;
 }
+
+export function formatMarkdownTableCodeSpan(value: string): string {
+  return escapeMarkdownTableCell(formatMarkdownCodeSpan(value));
+}
+
+export function escapeMarkdownLiteral(value: string): string {
+  const markdownCharacters = new Set(['\\', '`', '*', '_', '{', '}', '[', ']', '<', '>', '#', '|']);
+  return Array.from(value, character =>
+    markdownCharacters.has(character) ? `\\${character}` : character
+  ).join('');
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -21,6 +21,7 @@ import { resolveAccentColor } from '../defaults';
 import { verifyBugDropAuthToken } from '../lib/authToken';
 import { escapeMarkdownTableCell, formatMarkdownCodeSpan } from '../lib/markdown';
 import { handleStructuredFeedback, isStructuredFeedbackRequest } from './structured-feedback';
+import { parseAppVersion } from '../app-version';
 
 type ApiVariables = {
   feedbackPayload?: unknown;
@@ -840,6 +841,12 @@ function formatIssueBody(
   sections.push('');
   sections.push('| Property | Value |');
   sections.push('|----------|-------|');
+
+  const appVersion = parseAppVersion(payload.metadata.appVersion);
+  if (appVersion) {
+    const tableSafeAppVersion = escapeMarkdownTableCell(appVersion.replaceAll('\\', '\\\\'));
+    sections.push(`| **App Version** | ${tableSafeAppVersion} |`);
+  }
 
   // Browser and OS (if available)
   if (payload.metadata.browser) {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -19,7 +19,11 @@ import {
 import { rateLimit, rateLimitByRepo } from '../middleware/rateLimit';
 import { resolveAccentColor } from '../defaults';
 import { verifyBugDropAuthToken } from '../lib/authToken';
-import { escapeMarkdownTableCell, formatMarkdownCodeSpan } from '../lib/markdown';
+import {
+  escapeMarkdownTableCell,
+  formatMarkdownCodeSpan,
+  formatMarkdownTableCodeSpan,
+} from '../lib/markdown';
 import { handleStructuredFeedback, isStructuredFeedbackRequest } from './structured-feedback';
 import { parseAppVersion } from '../app-version';
 
@@ -122,6 +126,7 @@ api.get('/health', c => {
     status: 'ok',
     environment: c.env.ENVIRONMENT,
     timestamp: new Date().toISOString(),
+    capabilities: { appVersionMetadata: true },
     ...(buildSha ? { buildSha } : {}),
   });
 });
@@ -179,6 +184,12 @@ api.post('/feedback', async c => {
       },
       400
     );
+  }
+
+  if (payload.metadata?.appVersion !== undefined) {
+    const appVersion = parseAppVersion(payload.metadata.appVersion);
+    if (!appVersion) return c.json({ error: 'Invalid metadata appVersion' }, 400);
+    payload.metadata.appVersion = appVersion;
   }
 
   // Validate screenshot payload. The browser widget emits PNG data URLs, but
@@ -844,8 +855,7 @@ function formatIssueBody(
 
   const appVersion = parseAppVersion(payload.metadata.appVersion);
   if (appVersion) {
-    const tableSafeAppVersion = escapeMarkdownTableCell(appVersion.replaceAll('\\', '\\\\'));
-    sections.push(`| **App Version** | ${tableSafeAppVersion} |`);
+    sections.push(`| **App Version** | ${formatMarkdownTableCodeSpan(appVersion)} |`);
   }
 
   // Browser and OS (if available)

--- a/src/routes/structured-feedback.ts
+++ b/src/routes/structured-feedback.ts
@@ -9,6 +9,7 @@ import type {
   StructuredFeedbackPayload,
   StructuredFeedbackSectionFormat,
 } from '../types';
+import { parseAppVersion } from '../app-version';
 
 const STRUCTURED_KIND = 'bugdrop.variant-submission';
 const STRUCTURED_SCHEMA_VERSION = 1;
@@ -48,6 +49,7 @@ const METADATA_KEYS = new Set([
   'userAgent',
   'viewport',
   'timestamp',
+  'appVersion',
   'elementSelector',
   'fullElementSelector',
   'selectedElementHighlightColor',
@@ -355,6 +357,11 @@ function validateMetadata(
     viewport: { width, height },
     timestamp: value.timestamp,
   };
+  if (value.appVersion !== undefined) {
+    const appVersion = parseAppVersion(value.appVersion);
+    if (!appVersion) return invalid('Invalid structured metadata appVersion');
+    metadata.appVersion = appVersion;
+  }
   for (const key of [
     'elementSelector',
     'fullElementSelector',
@@ -505,6 +512,9 @@ function formatStructuredIssueBody(payload: StructuredFeedbackPayload, warnings:
 
   sections.push('<details>', '<summary>System Info</summary>', '');
   sections.push('| Property | Value |', '|----------|-------|');
+  if (payload.metadata.appVersion) {
+    sections.push(`| **App Version** | ${escapeTableValue(payload.metadata.appVersion)} |`);
+  }
   if (payload.metadata.browser) {
     sections.push(
       `| **Browser** | ${escapeTableValue(`${payload.metadata.browser.name} ${payload.metadata.browser.version}`.trim())} |`

--- a/src/routes/structured-feedback.ts
+++ b/src/routes/structured-feedback.ts
@@ -1,7 +1,11 @@
 /* eslint-disable max-lines -- Keep the isolated structured contract out of the legacy route. */
 import type { Context } from 'hono';
 import { GitHubLabelError, createIssue, getInstallationToken, isRepoPublic } from '../lib/github';
-import { formatMarkdownCodeSpan } from '../lib/markdown';
+import {
+  escapeMarkdownLiteral,
+  formatMarkdownCodeSpan,
+  formatMarkdownTableCodeSpan,
+} from '../lib/markdown';
 import type {
   Env,
   FeedbackMetadata,
@@ -499,21 +503,23 @@ function labelFallback(labels: string[], warning: string): LabelResolution {
 function formatStructuredIssueBody(payload: StructuredFeedbackPayload, warnings: string[]): string {
   const sections: string[] = [];
   for (const section of payload.issue.sections) {
-    sections.push(`## ${escapeMarkdown(section.heading)}`);
+    sections.push(`## ${escapeMarkdownLiteral(section.heading)}`);
     sections.push('');
     sections.push(formatSectionValue(section.value, section.format ?? 'text'));
     sections.push('');
   }
   if (warnings.length > 0) {
     sections.push('## Label mapping warning', '');
-    for (const warning of warnings) sections.push(`- ${escapeMarkdown(warning)}`);
+    for (const warning of warnings) sections.push(`- ${escapeMarkdownLiteral(warning)}`);
     sections.push('');
   }
 
   sections.push('<details>', '<summary>System Info</summary>', '');
   sections.push('| Property | Value |', '|----------|-------|');
   if (payload.metadata.appVersion) {
-    sections.push(`| **App Version** | ${escapeTableValue(payload.metadata.appVersion)} |`);
+    sections.push(
+      `| **App Version** | ${formatMarkdownTableCodeSpan(payload.metadata.appVersion)} |`
+    );
   }
   if (payload.metadata.browser) {
     sections.push(
@@ -544,7 +550,7 @@ function formatStructuredIssueBody(payload: StructuredFeedbackPayload, warnings:
 function formatSectionValue(value: string, format: StructuredFeedbackSectionFormat): string {
   const normalized = normalizeMultilineText(value);
   if (format === 'code') return formatFencedBlock(normalized);
-  const escaped = escapeMarkdown(normalized);
+  const escaped = escapeMarkdownLiteral(normalized);
   if (format === 'quote')
     return escaped
       .split('\n')
@@ -569,15 +575,8 @@ function normalizeMultilineText(value: string): string {
   return normalized;
 }
 
-function escapeMarkdown(value: string): string {
-  const markdownCharacters = new Set(['\\', '`', '*', '_', '{', '}', '[', ']', '<', '>', '#', '|']);
-  return Array.from(value, character =>
-    markdownCharacters.has(character) ? `\\${character}` : character
-  ).join('');
-}
-
 function escapeTableValue(value: string): string {
-  return escapeMarkdown(normalizeMultilineText(value).replace(/\n/g, ' '));
+  return escapeMarkdownLiteral(normalizeMultilineText(value).replace(/\n/g, ' '));
 }
 
 function formatFencedBlock(value: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface FeedbackMetadata {
   userAgent: string;
   viewport: { width: number; height: number };
   timestamp: string;
+  appVersion?: string;
   elementSelector?: string;
   fullElementSelector?: string;
   selectedElementHighlightColor?: string;

--- a/src/widget/flows/submission.ts
+++ b/src/widget/flows/submission.ts
@@ -11,6 +11,7 @@ export interface FlowTransportConfig {
   apiUrl: string;
   authTokenProvider?: BugDropAuthTokenProvider;
   categoryLabels?: Partial<Record<'bug' | 'feature' | 'question', string | string[]>>;
+  appVersion?: string;
 }
 
 export async function submitFlow(
@@ -45,7 +46,7 @@ export async function submitFlow(
       attachments: attachmentsPath ? (answers[attachmentsPath] ?? []) : [],
       consoleLogs: logsPath && answers[logsPath] === true ? getConsoleLogSnapshot() : undefined,
       submitter: submitter && (submitter.name || submitter.email) ? submitter : undefined,
-      metadata: collectMetadata(capture),
+      metadata: collectMetadata(capture, transport.appVersion),
     }),
   });
   if (response.status === 429) throw new Error('Too many submissions. Please try again later.');
@@ -85,7 +86,7 @@ function isCanonicalIssueUrl(value: string, repo: string, issueNumber: number): 
   }
 }
 
-function collectMetadata(capture: CaptureEvidence | null) {
+function collectMetadata(capture: CaptureEvidence | null, appVersion?: string) {
   const url = new URL(window.location.href);
   url.search = '';
   url.hash = '';
@@ -94,6 +95,7 @@ function collectMetadata(capture: CaptureEvidence | null) {
     userAgent: navigator.userAgent,
     viewport: { width: window.innerWidth, height: window.innerHeight },
     timestamp: new Date().toISOString(),
+    appVersion,
     elementSelector: capture?.elementSelector ?? null,
     fullElementSelector: capture?.fullElementSelector ?? null,
     domNodeCount: getDomNodeCount(),

--- a/src/widget/index.ts
+++ b/src/widget/index.ts
@@ -38,6 +38,7 @@ import { createVariantManager, type VariantManager } from './variants/manager';
 import { runDefaultJourney } from './default-flow/runtime';
 import { normalizeDefaultDefinition } from './default-flow/definition';
 import { createFlowManager, type FlowManager } from './flows/manager';
+import { parseAppVersion } from '../app-version';
 
 declare const __BUGDROP_ENABLE_TEST_HOOKS__: boolean;
 declare const __BUGDROP_DEFAULT_FLOW_RUNTIME__: 'fixed' | 'private';
@@ -55,6 +56,7 @@ interface WidgetConfig {
   repo: string;
   apiUrl: string;
   authTokenProvider?: BugDropAuthTokenProvider;
+  appVersion?: string;
   position: 'bottom-right' | 'bottom-left';
   theme: 'light' | 'dark' | 'auto';
   // Name/email field configuration
@@ -415,10 +417,16 @@ if (rawShowIssueLink && rawShowIssueLink !== 'public' && rawShowIssueLink !== is
     `[BugDrop] Invalid data-show-issue-link "${rawShowIssueLink}". Expected "public", "always", or "never".`
   );
 }
+const rawAppVersion = script?.dataset.appVersion;
+const appVersion = parseAppVersion(rawAppVersion);
+if (rawAppVersion !== undefined && appVersion === undefined) {
+  console.warn('[BugDrop] Invalid data-app-version. Expected 1 to 128 printable characters.');
+}
 const config: WidgetConfig = {
   repo: script?.dataset.repo || '',
   apiUrl: script?.src.replace(/\/widget(?:\.v[\d.]+)?\.js$/, '/api') || '',
   authTokenProvider: resolveAuthTokenProvider(script?.dataset.authTokenProvider),
+  appVersion,
   position: rawPosition === 'bottom-left' ? 'bottom-left' : 'bottom-right',
   theme: isValidTheme(rawTheme) ? rawTheme : 'auto', // Default to auto-detection
   // Name/email field configuration (all default to false for backwards compatibility)
@@ -984,6 +992,7 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
           repo: config.repo,
           apiUrl: config.apiUrl,
           authTokenProvider: config.authTokenProvider,
+          appVersion: config.appVersion,
         },
         { isLegacyModalOpen: () => _isModalOpen }
       );
@@ -997,6 +1006,7 @@ function exposeBugDropAPI(root: HTMLElement, config: WidgetConfig) {
           apiUrl: config.apiUrl,
           authTokenProvider: config.authTokenProvider,
           categoryLabels: config.categoryLabels,
+          appVersion: config.appVersion,
         },
         {
           preflight: () => checkInstallation(config),
@@ -1797,6 +1807,7 @@ async function submitFeedback(root: HTMLElement, config: WidgetConfig, data: Fee
             height: window.innerHeight,
           },
           timestamp: new Date().toISOString(),
+          appVersion: config.appVersion,
           elementSelector: data.elementSelector,
           fullElementSelector: data.fullElementSelector,
           selectedElementHighlightColor: data.selectedElementHighlightColor || undefined,

--- a/src/widget/variants/submission.ts
+++ b/src/widget/variants/submission.ts
@@ -9,6 +9,11 @@ export interface VariantTransportConfig {
   appVersion?: string;
 }
 
+const LEGACY_APP_VERSION_ERROR = 'Unknown structured metadata property: appVersion';
+const APP_VERSION_CAPABILITY_TIMEOUT_MS = 1500;
+
+const appVersionCapabilityProbes = new Map<string, Promise<boolean>>();
+
 export async function submitVariant(
   transport: VariantTransportConfig,
   config: Readonly<VariantConfig>,
@@ -17,23 +22,36 @@ export async function submitVariant(
 ): Promise<SubmissionResult> {
   const submissionId = options.submissionId ?? createSubmissionId();
   const issue = compileIssueDraft(config, answers, options.context);
-  const response = await fetch(`${transport.apiUrl}/feedback`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      ...(await getAuthHeaders(transport.authTokenProvider)),
-    },
-    body: JSON.stringify({
-      kind: 'bugdrop.variant-submission',
-      schemaVersion: 1,
-      repo: transport.repo,
-      variantId: config.id,
-      submissionId,
-      issue,
-      metadata: collectMetadata(transport.appVersion),
-    }),
-  });
-  const result = (await response.json()) as Record<string, unknown>;
+  const headers = {
+    'Content-Type': 'application/json',
+    ...(await getAuthHeaders(transport.authTokenProvider)),
+  };
+  const appVersion = await resolveAppVersion(transport);
+  const metadata = collectMetadata(appVersion);
+  const payload = {
+    kind: 'bugdrop.variant-submission',
+    schemaVersion: 1,
+    repo: transport.repo,
+    variantId: config.id,
+    submissionId,
+    issue,
+    metadata,
+  };
+  let response = await postVariantSubmission(transport.apiUrl, headers, payload);
+  let result = (await response.json()) as Record<string, unknown>;
+  if (
+    appVersion !== undefined &&
+    response.status === 400 &&
+    !response.ok &&
+    result.error === LEGACY_APP_VERSION_ERROR
+  ) {
+    console.warn('[BugDrop] Worker does not support app-version metadata; retrying without it.');
+    response = await postVariantSubmission(transport.apiUrl, headers, {
+      ...payload,
+      metadata: { ...metadata, appVersion: undefined },
+    });
+    result = (await response.json()) as Record<string, unknown>;
+  }
   if (!response.ok || result.success !== true) {
     throw new Error(typeof result.error === 'string' ? result.error : 'Failed to submit feedback');
   }
@@ -55,6 +73,82 @@ export async function submitVariant(
       ? { labelMappingWarnings: result.labelMappingWarnings as string[] }
       : {}),
   };
+}
+
+function postVariantSubmission(
+  apiUrl: string,
+  headers: Record<string, string>,
+  payload: Record<string, unknown>
+): Promise<Response> {
+  return fetch(`${apiUrl}/feedback`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+}
+
+async function resolveAppVersion(transport: VariantTransportConfig): Promise<string | undefined> {
+  if (transport.appVersion === undefined) return undefined;
+  return (await workerSupportsAppVersion(transport.apiUrl)) ? transport.appVersion : undefined;
+}
+
+async function workerSupportsAppVersion(apiUrl: string): Promise<boolean> {
+  const inFlight = appVersionCapabilityProbes.get(apiUrl);
+  if (inFlight) return inFlight;
+
+  const probe = probeAppVersionCapability(apiUrl).then(supported => supported === true);
+  appVersionCapabilityProbes.set(apiUrl, probe);
+  try {
+    return await probe;
+  } finally {
+    if (appVersionCapabilityProbes.get(apiUrl) === probe) {
+      appVersionCapabilityProbes.delete(apiUrl);
+    }
+  }
+}
+
+async function probeAppVersionCapability(apiUrl: string): Promise<boolean | undefined> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), APP_VERSION_CAPABILITY_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${apiUrl}/health`, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      console.warn(
+        `[BugDrop] App-version capability probe returned HTTP ${response.status}; submitting without it.`
+      );
+      return undefined;
+    }
+    const health: unknown = await response.json();
+    if (!isRecord(health) || health.status !== 'ok') {
+      console.warn(
+        '[BugDrop] App-version capability probe returned an invalid response; submitting without it.'
+      );
+      return undefined;
+    }
+    if (health.capabilities === undefined) return false;
+    if (
+      !isRecord(health.capabilities) ||
+      typeof health.capabilities.appVersionMetadata !== 'boolean'
+    ) {
+      console.warn(
+        '[BugDrop] App-version capability probe returned an invalid response; submitting without it.'
+      );
+      return undefined;
+    }
+    return health.capabilities.appVersionMetadata;
+  } catch (error) {
+    console.warn('[BugDrop] App-version capability probe failed; submitting without it.', error);
+    return undefined;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function createSubmissionId(): string {

--- a/src/widget/variants/submission.ts
+++ b/src/widget/variants/submission.ts
@@ -6,6 +6,7 @@ export interface VariantTransportConfig {
   repo: string;
   apiUrl: string;
   authTokenProvider?: BugDropAuthTokenProvider;
+  appVersion?: string;
 }
 
 export async function submitVariant(
@@ -29,7 +30,7 @@ export async function submitVariant(
       variantId: config.id,
       submissionId,
       issue,
-      metadata: collectMetadata(),
+      metadata: collectMetadata(transport.appVersion),
     }),
   });
   const result = (await response.json()) as Record<string, unknown>;
@@ -65,7 +66,7 @@ function createSubmissionId(): string {
   return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
-function collectMetadata() {
+function collectMetadata(appVersion?: string) {
   const url = new URL(window.location.href);
   url.search = '';
   url.hash = '';
@@ -74,6 +75,7 @@ function collectMetadata() {
     userAgent: navigator.userAgent,
     viewport: { width: window.innerWidth, height: window.innerHeight },
     timestamp: new Date().toISOString(),
+    appVersion,
     browser: parseBrowser(navigator.userAgent),
     os: parseOS(navigator.userAgent),
     devicePixelRatio: window.devicePixelRatio,

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -91,6 +91,7 @@ describe('API Routes', () => {
       expect(data).toMatchObject({
         status: 'ok',
         environment: 'test',
+        capabilities: { appVersionMetadata: true },
       });
       expect(data.timestamp).toBeDefined();
     });
@@ -1369,6 +1370,26 @@ describe('API Routes', () => {
       expect(data.error).toContain('Missing required fields');
     });
 
+    it.each([123, '', '1.2.3\nforged', 'v'.repeat(129)])(
+      'should reject invalid application version metadata: %j',
+      async appVersion => {
+        const req = new Request('http://localhost/feedback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...validPayload,
+            metadata: { ...validPayload.metadata, appVersion },
+          }),
+        });
+        const res = await app.fetch(req, mockEnv);
+        const data = await res.json();
+
+        expect(res.status).toBe(400);
+        expect(data.error).toBe('Invalid metadata appVersion');
+        expect(mockCreateIssue).not.toHaveBeenCalled();
+      }
+    );
+
     it('should accept submission when description is missing (optional field)', async () => {
       const payload = { ...validPayload, description: undefined };
 
@@ -1803,7 +1824,7 @@ describe('API Routes', () => {
         ...validPayload,
         metadata: {
           ...validPayload.metadata,
-          appVersion: '  1.2.3\\|desktop  ',
+          appVersion: '  1.2.3 [download](https://attacker.test)<details>|desktop  ',
           elementSelector: '#submit-button',
           fullElementSelector: 'html > body > main > form#contact > button#submit-button',
         },
@@ -1820,7 +1841,9 @@ describe('API Routes', () => {
       expect(issueBody).toContain('## Description');
       expect(issueBody).toContain('This is a test feedback');
       expect(issueBody).toContain('System Info');
-      expect(issueBody).toContain('| **App Version** | 1.2.3\\\\\\|desktop |');
+      expect(issueBody).toContain(
+        '| **App Version** | `1.2.3 [download](https://attacker.test)<details>\\|desktop` |'
+      );
       expect(issueBody).toContain('http://localhost:3000');
       expect(issueBody).toContain('1920×1080');
       expect(issueBody).toContain('#submit-button');

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1803,6 +1803,7 @@ describe('API Routes', () => {
         ...validPayload,
         metadata: {
           ...validPayload.metadata,
+          appVersion: '  1.2.3\\|desktop  ',
           elementSelector: '#submit-button',
           fullElementSelector: 'html > body > main > form#contact > button#submit-button',
         },
@@ -1819,6 +1820,7 @@ describe('API Routes', () => {
       expect(issueBody).toContain('## Description');
       expect(issueBody).toContain('This is a test feedback');
       expect(issueBody).toContain('System Info');
+      expect(issueBody).toContain('| **App Version** | 1.2.3\\\\\\|desktop |');
       expect(issueBody).toContain('http://localhost:3000');
       expect(issueBody).toContain('1920×1080');
       expect(issueBody).toContain('#submit-button');

--- a/test/appVersion.test.ts
+++ b/test/appVersion.test.ts
@@ -4,6 +4,9 @@ import { MAX_APP_VERSION_CHARS, parseAppVersion } from '../src/app-version';
 describe('application version metadata', () => {
   it('normalizes a bounded printable version', () => {
     expect(parseAppVersion('  1.2.3+desktop.4  ')).toBe('1.2.3+desktop.4');
+    expect(parseAppVersion('v'.repeat(MAX_APP_VERSION_CHARS))).toBe(
+      'v'.repeat(MAX_APP_VERSION_CHARS)
+    );
   });
 
   it.each([
@@ -15,6 +18,8 @@ describe('application version metadata', () => {
     '1.2.3\nforged',
     '1.2.3\u007fforged',
     '1.2.3\u0085forged',
+    '1.2.3\u202eforged',
+    '1.2.3\u2028forged',
     'v'.repeat(MAX_APP_VERSION_CHARS + 1),
   ])('rejects invalid version metadata: %j', value => {
     expect(parseAppVersion(value)).toBeUndefined();

--- a/test/appVersion.test.ts
+++ b/test/appVersion.test.ts
@@ -7,6 +7,9 @@ describe('application version metadata', () => {
     expect(parseAppVersion('v'.repeat(MAX_APP_VERSION_CHARS))).toBe(
       'v'.repeat(MAX_APP_VERSION_CHARS)
     );
+    expect(parseAppVersion('🚀'.repeat(MAX_APP_VERSION_CHARS))).toBe(
+      '🚀'.repeat(MAX_APP_VERSION_CHARS)
+    );
   });
 
   it.each([
@@ -21,6 +24,7 @@ describe('application version metadata', () => {
     '1.2.3\u202eforged',
     '1.2.3\u2028forged',
     'v'.repeat(MAX_APP_VERSION_CHARS + 1),
+    '🚀'.repeat(MAX_APP_VERSION_CHARS + 1),
   ])('rejects invalid version metadata: %j', value => {
     expect(parseAppVersion(value)).toBeUndefined();
   });

--- a/test/appVersion.test.ts
+++ b/test/appVersion.test.ts
@@ -23,6 +23,10 @@ describe('application version metadata', () => {
     '1.2.3\u0085forged',
     '1.2.3\u202eforged',
     '1.2.3\u2028forged',
+    '\nv1.2.3',
+    'v1.2.3\u2029',
+    '\uFEFFv1.2.3',
+    '\ud800',
     'v'.repeat(MAX_APP_VERSION_CHARS + 1),
     '🚀'.repeat(MAX_APP_VERSION_CHARS + 1),
   ])('rejects invalid version metadata: %j', value => {

--- a/test/appVersion.test.ts
+++ b/test/appVersion.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_APP_VERSION_CHARS, parseAppVersion } from '../src/app-version';
+
+describe('application version metadata', () => {
+  it('normalizes a bounded printable version', () => {
+    expect(parseAppVersion('  1.2.3+desktop.4  ')).toBe('1.2.3+desktop.4');
+  });
+
+  it.each([
+    undefined,
+    null,
+    123,
+    '',
+    '   ',
+    '1.2.3\nforged',
+    '1.2.3\u007fforged',
+    '1.2.3\u0085forged',
+    'v'.repeat(MAX_APP_VERSION_CHARS + 1),
+  ])('rejects invalid version metadata: %j', value => {
+    expect(parseAppVersion(value)).toBeUndefined();
+  });
+});

--- a/test/flowSubmission.test.ts
+++ b/test/flowSubmission.test.ts
@@ -29,6 +29,7 @@ describe('flow legacy submission', () => {
         repo: 'owner/repo',
         apiUrl: '/api',
         categoryLabels: { bug: ['defect', 'needs-triage'] },
+        appVersion: '1.2.3',
       },
       config,
       {
@@ -55,6 +56,7 @@ describe('flow legacy submission', () => {
       attachments: [{ name: 'trace.txt' }],
       submitter: { name: 'Ada' },
       metadata: {
+        appVersion: '1.2.3',
         elementSelector: '#save',
         fullElementSelector: 'html body #save',
       },

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { escapeMarkdownTableCell, formatMarkdownCodeSpan } from '../src/lib/markdown';
+import {
+  escapeMarkdownLiteral,
+  escapeMarkdownTableCell,
+  formatMarkdownCodeSpan,
+  formatMarkdownTableCodeSpan,
+} from '../src/lib/markdown';
 
 describe('Markdown formatting', () => {
   it('uses a code-span fence longer than embedded backticks without rewriting backslashes', () => {
@@ -13,5 +18,17 @@ describe('Markdown formatting', () => {
     ['unrelated backslash', String.raw`action\primary|safe`, String.raw`action\primary\|safe`],
   ])('keeps table delimiters escaped for %s', (_name, input, expected) => {
     expect(escapeMarkdownTableCell(input)).toBe(expected);
+  });
+
+  it('renders untrusted Markdown and HTML as literal text', () => {
+    expect(escapeMarkdownLiteral('[download](https://attacker.test)<details>|v1')).toBe(
+      String.raw`\[download\](https://attacker.test)\<details\>\|v1`
+    );
+  });
+
+  it('renders table values as code without exposing table delimiters', () => {
+    expect(formatMarkdownTableCodeSpan('https://attacker.test ~~v1~~|`build`')).toBe(
+      '`` https://attacker.test ~~v1~~\\|`build` ``'
+    );
   });
 });

--- a/test/structuredFeedback.test.ts
+++ b/test/structuredFeedback.test.ts
@@ -45,6 +45,7 @@ const validPayload: StructuredFeedbackPayload = {
     userAgent: 'FrozenAgent/1.0',
     viewport: { width: 1280, height: 720 },
     timestamp: '2026-08-02T12:34:56.000Z',
+    appVersion: '1.2.3|desktop',
     browser: { name: 'Chrome', version: '126.0' },
     os: { name: 'macOS', version: '14.5' },
     devicePixelRatio: 2,
@@ -65,6 +66,7 @@ const expectedBody = `## Rating
 
 | Property | Value |
 |----------|-------|
+| **App Version** | 1.2.3\\|desktop |
 | **Browser** | Chrome 126.0 |
 | **OS** | macOS 14.5 |
 | **Viewport** | 1280×720 @2x |
@@ -130,6 +132,17 @@ describe('structured feedback Worker contract', () => {
       ['bugdrop']
     );
     expect(mockGetInstallationToken).toHaveBeenCalledOnce();
+  });
+
+  it('omits App Version when metadata does not provide one', async () => {
+    const payload = structuredClone(validPayload);
+    delete payload.metadata.appVersion;
+
+    const response = await submit(payload);
+    const body = mockCreateIssue.mock.calls[0][4] as string;
+
+    expect(response.status).toBe(200);
+    expect(body).not.toContain('App Version');
   });
 
   it('formats a hypothetical contributor field as generic sections without a Worker branch', async () => {
@@ -289,6 +302,20 @@ describe('structured feedback Worker contract', () => {
       {
         ...validPayload,
         metadata: { ...validPayload.metadata, viewport: { width: NaN, height: 1 } },
+      },
+    ],
+    [
+      'oversized app version',
+      {
+        ...validPayload,
+        metadata: { ...validPayload.metadata, appVersion: 'v'.repeat(129) },
+      },
+    ],
+    [
+      'app version with control characters',
+      {
+        ...validPayload,
+        metadata: { ...validPayload.metadata, appVersion: '1.2.3\nforged' },
       },
     ],
   ])('rejects %s before any GitHub call', async (_name, payload) => {

--- a/test/structuredFeedback.test.ts
+++ b/test/structuredFeedback.test.ts
@@ -66,7 +66,7 @@ const expectedBody = `## Rating
 
 | Property | Value |
 |----------|-------|
-| **App Version** | 1.2.3\\|desktop |
+| **App Version** | \`1.2.3\\|desktop\` |
 | **Browser** | Chrome 126.0 |
 | **OS** | macOS 14.5 |
 | **Viewport** | 1280×720 @2x |

--- a/test/variantSubmission.test.ts
+++ b/test/variantSubmission.test.ts
@@ -70,7 +70,7 @@ describe('variant submission transport', () => {
 
     await expect(
       submitVariant(
-        { ...transport, authTokenProvider: tokenProvider },
+        { ...transport, authTokenProvider: tokenProvider, appVersion: '1.2.3' },
         config,
         { rating: 4 },
         { context: { export_id: 'exp-42' }, submissionId: 'submission-fixed' }
@@ -110,6 +110,7 @@ describe('variant submission transport', () => {
         userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) Chrome/126.0.0.0 Safari/537.36',
         viewport: { width: 1440, height: 900 },
         timestamp: '2026-02-03T04:05:06.789Z',
+        appVersion: '1.2.3',
         browser: { name: 'Chrome', version: '126.0.0.0' },
         os: { name: 'macOS', version: '14.5' },
         devicePixelRatio: 2,

--- a/test/variantSubmission.test.ts
+++ b/test/variantSubmission.test.ts
@@ -20,8 +20,8 @@ const transport = {
   apiUrl: 'https://api.example.test/v1',
 };
 
-function jsonResponse(body: unknown, ok = true): Response {
-  return { ok, json: vi.fn().mockResolvedValue(body) } as unknown as Response;
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 400): Response {
+  return { ok, status, json: vi.fn().mockResolvedValue(body) } as unknown as Response;
 }
 
 describe('variant submission transport', () => {
@@ -57,15 +57,19 @@ describe('variant submission transport', () => {
 
   it('sends the exact URL, method, headers, authentication, payload, and redacted metadata', async () => {
     const fetchMock = vi.mocked(fetch);
-    fetchMock.mockResolvedValueOnce(
-      jsonResponse({
-        success: true,
-        issueNumber: 37,
-        issueUrl: 'https://github.com/owner/repo/issues/37',
-        isPublic: true,
-        labelMappingWarnings: ['fallback label used'],
-      })
-    );
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: true } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 37,
+          issueUrl: 'https://github.com/owner/repo/issues/37',
+          isPublic: true,
+          labelMappingWarnings: ['fallback label used'],
+        })
+      );
     const tokenProvider = vi.fn().mockResolvedValue('private-token');
 
     await expect(
@@ -83,8 +87,9 @@ describe('variant submission transport', () => {
     });
 
     expect(tokenProvider).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://api.example.test/v1/health');
+    const [url, init] = fetchMock.mock.calls[1]!;
     expect(url).toBe('https://api.example.test/v1/feedback');
     expect(init).toEqual({
       method: 'POST',
@@ -148,6 +153,328 @@ describe('variant submission transport', () => {
     });
     expect(JSON.parse(String(init?.body)).submissionId).toBe(
       '123e4567-e89b-42d3-a456-426614174000'
+    );
+  });
+
+  it('omits appVersion for an older Worker and detects an upgrade on the next submission', async () => {
+    const legacyTransport = { ...transport, apiUrl: 'https://legacy-api.example.test/v1' };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ status: 'ok' })).mockResolvedValueOnce(
+      jsonResponse({
+        success: true,
+        issueNumber: 38,
+        issueUrl: 'https://github.com/owner/repo/issues/38',
+        isPublic: true,
+      })
+    );
+
+    await expect(
+      submitVariant(
+        { ...legacyTransport, appVersion: '1.2.3' },
+        config,
+        { rating: 4 },
+        { submissionId: 'legacy-worker-retry' }
+      )
+    ).resolves.toMatchObject({ issueNumber: 38 });
+
+    expect(fetchMock.mock.calls[0]![0]).toBe('https://legacy-api.example.test/v1/health');
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).not.toHaveProperty(
+      'appVersion'
+    );
+
+    fetchMock.mockClear();
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: true } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 40,
+          issueUrl: 'https://github.com/owner/repo/issues/40',
+          isPublic: true,
+        })
+      );
+    await submitVariant(
+      { ...legacyTransport, appVersion: '1.2.5' },
+      config,
+      { rating: 5 },
+      { submissionId: 'legacy-worker-upgraded' }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).toMatchObject({
+      appVersion: '1.2.5',
+    });
+  });
+
+  it('reprobes supported endpoints so a Worker rollback does not spend fallback quota', async () => {
+    const rollbackTransport = {
+      ...transport,
+      apiUrl: 'https://rollback-api.example.test/v1',
+      appVersion: '1.2.3',
+    };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: true } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 48,
+          issueUrl: 'https://github.com/owner/repo/issues/48',
+          isPublic: true,
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ status: 'ok' }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 49,
+          issueUrl: 'https://github.com/owner/repo/issues/49',
+          isPublic: true,
+        })
+      );
+
+    await submitVariant(rollbackTransport, config, { rating: 4 });
+    await submitVariant(rollbackTransport, config, { rating: 5 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).toHaveProperty(
+      'appVersion'
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[3]![1]?.body)).metadata).not.toHaveProperty(
+      'appVersion'
+    );
+  });
+
+  it('retries once without appVersion after a stale positive capability result', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: true } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ error: 'Unknown structured metadata property: appVersion' }, false)
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 41,
+          issueUrl: 'https://github.com/owner/repo/issues/41',
+          isPublic: true,
+        })
+      );
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      submitVariant(
+        { ...transport, apiUrl: 'https://stale-api.example.test/v1', appVersion: '1.2.3' },
+        config,
+        { rating: 4 }
+      )
+    ).resolves.toMatchObject({ issueNumber: 41 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).toHaveProperty(
+      'appVersion'
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[2]![1]?.body)).metadata).not.toHaveProperty(
+      'appVersion'
+    );
+    expect(warning).toHaveBeenCalledWith(
+      '[BugDrop] Worker does not support app-version metadata; retrying without it.'
+    );
+  });
+
+  it('does not retry an appVersion rejection from a non-validation response', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: true } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ error: 'Unknown structured metadata property: appVersion' }, false, 500)
+      );
+
+    await expect(
+      submitVariant(
+        { ...transport, apiUrl: 'https://failing-api.example.test/v1', appVersion: '1.2.3' },
+        config,
+        { rating: 4 }
+      )
+    ).rejects.toThrow('Unknown structured metadata property: appVersion');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds a stalled capability probe and submits without appVersion', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockImplementationOnce(
+        (_input, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener('abort', () =>
+              reject(new DOMException('Aborted', 'AbortError'))
+            );
+          })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 42,
+          issueUrl: 'https://github.com/owner/repo/issues/42',
+          isPublic: true,
+        })
+      );
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const submission = submitVariant(
+      { ...transport, apiUrl: 'https://stalled-api.example.test/v1', appVersion: '1.2.3' },
+      config,
+      { rating: 4 }
+    );
+    await vi.advanceTimersByTimeAsync(1500);
+    await expect(submission).resolves.toMatchObject({ issueNumber: 42 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).not.toHaveProperty(
+      'appVersion'
+    );
+    expect(warning).toHaveBeenCalledWith(
+      '[BugDrop] App-version capability probe failed; submitting without it.',
+      expect.objectContaining({ name: 'AbortError' })
+    );
+  });
+
+  it('does not cache an indeterminate capability response', async () => {
+    const indeterminateTransport = {
+      ...transport,
+      apiUrl: 'https://indeterminate-api.example.test/v1',
+      appVersion: '1.2.3',
+    };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'unavailable' }, false, 503))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 43,
+          issueUrl: 'https://github.com/owner/repo/issues/43',
+          isPublic: true,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: true } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 44,
+          issueUrl: 'https://github.com/owner/repo/issues/44',
+          isPublic: true,
+        })
+      );
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await submitVariant(indeterminateTransport, config, { rating: 4 });
+    await submitVariant(indeterminateTransport, config, { rating: 5 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).not.toHaveProperty(
+      'appVersion'
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[3]![1]?.body)).metadata).toMatchObject({
+      appVersion: '1.2.3',
+    });
+    expect(warning).toHaveBeenCalledWith(
+      '[BugDrop] App-version capability probe returned HTTP 503; submitting without it.'
+    );
+  });
+
+  it('does not cache a malformed capability response', async () => {
+    const malformedTransport = {
+      ...transport,
+      apiUrl: 'https://malformed-api.example.test/v1',
+      appVersion: '1.2.3',
+    };
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: 'true' } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 46,
+          issueUrl: 'https://github.com/owner/repo/issues/46',
+          isPublic: true,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ status: 'ok', capabilities: { appVersionMetadata: true } })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 47,
+          issueUrl: 'https://github.com/owner/repo/issues/47',
+          isPublic: true,
+        })
+      );
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await submitVariant(malformedTransport, config, { rating: 4 });
+    await submitVariant(malformedTransport, config, { rating: 5 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).not.toHaveProperty(
+      'appVersion'
+    );
+    expect(JSON.parse(String(fetchMock.mock.calls[3]![1]?.body)).metadata).toMatchObject({
+      appVersion: '1.2.3',
+    });
+    expect(warning).toHaveBeenCalledWith(
+      '[BugDrop] App-version capability probe returned an invalid response; submitting without it.'
+    );
+  });
+
+  it('keeps the capability timeout active while reading the response body', async () => {
+    const fetchMock = vi.mocked(fetch);
+    fetchMock
+      .mockImplementationOnce((_input, init) =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener('abort', () =>
+                reject(new DOMException('Aborted', 'AbortError'))
+              );
+            }),
+        } as Response)
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          issueNumber: 45,
+          issueUrl: 'https://github.com/owner/repo/issues/45',
+          isPublic: true,
+        })
+      );
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const submission = submitVariant(
+      { ...transport, apiUrl: 'https://stalled-body.example.test/v1', appVersion: '1.2.3' },
+      config,
+      { rating: 4 }
+    );
+    await vi.advanceTimersByTimeAsync(1500);
+
+    await expect(submission).resolves.toMatchObject({ issueNumber: 45 });
+    expect(JSON.parse(String(fetchMock.mock.calls[1]![1]?.body)).metadata).not.toHaveProperty(
+      'appVersion'
     );
   });
 


### PR DESCRIPTION
## Summary

- add an optional `data-app-version` widget attribute
- propagate the host version through legacy, flow, and structured variant submissions
- render a validated, inline-code `App Version` row in the System Info table
- negotiate structured-metadata support through `/health` with a bounded probe on each structured
  submission; retain one exact HTTP 400 retry for deployment-transition mismatches
- document the attribute and cover validation, propagation, omission, rollback compatibility, and
  the public widget entry point

## Why

Embedded applications need the running host version in feedback reports so maintainers can correlate a report with the shipped binary without asking the reporter for a second diagnostic round.

The value is treated as untrusted metadata: the widget and Worker normalize it, reject empty,
oversized, control, separator, or Unicode-format values, and render it as a table-safe code span.
The capability probe is bounded to 1.5 seconds and fails open by omitting only the version. Probe
results are not cached, so Worker upgrades and rollbacks take effect on the next submission.
Indeterminate results are observable. The compatibility retry is restricted to the exact HTTP 400
validation response from pre-feature Workers; all other errors remain fail-closed.

Closes #341

## Testing

- `npx vitest run test/appVersion.test.ts test/markdown.test.ts test/api.test.ts test/flowSubmission.test.ts test/variantSubmission.test.ts test/structuredFeedback.test.ts` (193 passed)
- `npx playwright test e2e/local-submissions.spec.ts e2e/api.spec.ts --project=chromium` (17 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run knip`
- `npm run build:widget`
- `npm test` (1499 passed; 2 immutable legacy gzip-size assertions differ under local Node v26.7.0, while the recorded raw byte counts and SHA-256 hashes still match)
