### PR TITLE
docs: publish updated privacy policy

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,40 +1,188 @@
 # Privacy Policy
 
-**Last updated:** February 2025
+**Last updated:** August 27, 2026
 
-BugDrop is an open-source feedback widget that creates GitHub Issues with screenshots. This policy explains what data is collected and how it is used.
+BugDrop is an open-source feedback widget that creates GitHub Issues. This policy covers
+the hosted BugDrop widget and service, as well as the BugDrop website at
+[bugdrop.dev](https://bugdrop.dev).
 
-## What BugDrop Collects
+## Feedback Data
 
-When a user submits feedback through the BugDrop widget, the following data is collected:
+When someone submits feedback, BugDrop processes:
 
-- **Screenshot** — captured client-side only when the user initiates a submission
-- **Feedback content** — the title, description, and category the user enters
-- **Browser information** — browser name/version, operating system, viewport size, device pixel ratio, and language preference
-- **Page URL** — the URL of the page where feedback was submitted (query parameters are redacted)
-- **Name and email** — only if the site owner has enabled these optional fields and the user provides them
+- The submitted title, description, category, and optional attachments
+- A screenshot when the site configures screenshots as optional, automatic, or required;
+  automatic mode captures and attaches a full-page screenshot on submission without a
+  preview
+- Browser, operating system, viewport, language, and page information
+- Recent console messages, timestamps, and source locations, only when the reporter chooses
+  to include console logs
+- Optional name and email fields, when enabled by the site owner and completed by the
+  reporter
 
-## What BugDrop Does NOT Collect
+This data is used only to create the requested GitHub Issue and associated files. Feedback
+content is not retained in a BugDrop analytics database. It is sent to GitHub and stored
+in the repository selected by the site owner.
 
-- No cookies are set by the widget
-- No analytics or tracking scripts are included
-- No data is sold or shared with third parties
-- No personal data is stored by the BugDrop service itself
+The widget keeps a limited number of recent console entries in browser memory while the
+page is open. Console entries are not sent unless the reporter chooses to include them.
+BugDrop applies best-effort secret redaction, but console output can still contain personal
+or confidential information. Reporters should consider that risk before choosing to
+include it.
 
-## Where Data Goes
+## Installation and Usage Information
 
-All submitted feedback is sent to the **GitHub API** and created as a GitHub Issue in the repository configured by the site owner. Screenshots are stored in the repository's `.bugdrop/` directory on the `bugdrop-screenshots` branch. The BugDrop Cloudflare Worker acts only as a pass-through to authenticate with GitHub — it does not store any submitted data.
+BugDrop does not currently retain identifiable installation analytics. After automated
+deletion for uninstalled apps and a verifiable cleanup backstop are in place, the hosted
+service may retain a minimal installation record containing:
 
-Feedback and screenshots are unauthenticated user-generated content. The hosted service applies rate limits, size limits, and PNG screenshot validation, but it does not provide email-grade spam or malware filtering.
+- GitHub App installation ID
+- Public GitHub account name, account type, and profile link
+- Installation, suspension, removal, and last-active dates
+- Total number of feedback issues successfully created through that installation
 
-## Data Processing
+BugDrop does not retain repository names, issue content, screenshots, page URLs,
+reporter identities, or IP addresses for product analytics.
 
-BugDrop runs on **Cloudflare Workers**. Requests are processed in-memory and are not logged or persisted by the BugDrop service. Cloudflare's standard infrastructure policies apply to network-level processing.
+This information is used to operate BugDrop, understand aggregate adoption and usage,
+maintain accurate public totals, and invite app owners to participate voluntarily in
+product research or social proof.
+
+## Public Statistics
+
+BugDrop may publish rounded, aggregate statistics such as:
+
+- Total GitHub App installations
+- Total feedback issues created
+
+Public statistics are not broken down by installation and do not identify individual
+apps, repositories, or reporters.
+
+## App Names, Logos, Links, and Testimonials
+
+Installing or using BugDrop does not give BugDrop permission to publicly identify an app
+or organization.
+
+BugDrop will display an app name, logo, link, quote, or testimonial only after receiving
+explicit permission from an authorized representative. That permission may be withdrawn
+at any time.
+
+## What BugDrop Does Not Collect for Analytics
+
+BugDrop does not:
+
+- Track individual feedback reporters
+- Build profiles of reporters
+- Store feedback content or screenshots outside GitHub
+- Retain repository names for product analytics
+- Sell personal information
+- Share installation information for advertising
+- Use widget telemetry for cross-site tracking or fingerprinting
+
+The widget does not set analytics cookies or use browser storage to track reporters.
+
+## Website Analytics
+
+The bugdrop.dev marketing and documentation website uses limited analytics to understand
+page visits, referral sources, campaign attribution, interactions, and site performance.
+
+Website analytics are separate from the BugDrop widget. The website stores a random
+analytics identifier and first-touch attribution information in browser storage. It may
+send query-free page paths and page locations, query-free referrer locations, coarse
+referrer and campaign categories, controlled interaction labels and destinations, and
+site-performance measurements to Google Analytics and PostHog. Raw query values and full
+referrer URLs are not included in BugDrop's custom analytics events. Those analytics are
+not connected to feedback content or reporter identities.
+
+Google Analytics enhanced measurement is enabled for page views, scrolling, outbound
+links, embedded video engagement, file downloads, and form interactions. Automatic site
+search measurement is disabled so Google Analytics does not extract search terms from URL
+query parameters.
+
+The analytics providers receive network information needed to process requests, including
+IP addresses. PostHog may use a client IP address temporarily for pre-storage processing,
+such as geolocation or bot detection, but the project is configured to discard the raw IP
+before storing the event.
+
+The values stored by BugDrop in the browser do not currently expire automatically and
+remain until the visitor clears the site's browser data. Google Analytics and PostHog may
+set additional cookies or browser identifiers. Visitors can block browser storage or
+analytics requests using their browser or privacy tools. BugDrop does not currently offer
+a first-party analytics opt-out control.
+
+Website analytics retention is described in the Retention section below.
+
+## Where Feedback Data Goes
+
+Feedback is sent to the GitHub API and created as a GitHub Issue in the repository
+configured by the site owner. Screenshots are stored in that repository's `.bugdrop/`
+directory, and attachments are stored in `.bugdrop/uploads/`, on the
+`bugdrop-screenshots` branch. Included console logs are written into the GitHub Issue body.
+
+The hosted BugDrop service runs on Cloudflare Workers and processes submissions in memory
+while communicating with GitHub.
+
+## Abuse Prevention and Operational Data
+
+The hosted service temporarily stores rate-limit counters to prevent abuse:
+
+- A counter keyed by the raw client IP address expires 15 minutes after its most recent
+  update.
+- A counter keyed by the destination repository name expires one hour after its most
+  recent update.
+
+These identifiers are used only to enforce submission limits and are not used for product
+analytics. Cloudflare may also temporarily process request and network metadata, including
+request paths, for service delivery, security, and operational logs.
+
+## Retention
+
+- Feedback content is discarded by the hosted service after the GitHub request completes.
+- IP-based rate-limit records expire 15 minutes after their most recent update.
+- Repository-based rate-limit records expire one hour after their most recent update.
+- Identifiable installation analytics are not currently retained. If enabled after
+  automated deletion for uninstalled apps and a verifiable cleanup backstop are in place,
+  installation records may be retained while an installation is active.
+- Anonymous aggregate totals may be retained indefinitely.
+- Testimonial and contact information provided with explicit permission is retained until
+  that permission is withdrawn or the information is no longer needed.
+- Website analytics identifiers stored in the browser remain until the visitor clears the
+  site's browser data.
+- Google Analytics retains identifier-associated event data for two months and user data
+  for 14 months; the user-data period resets with new activity. Aggregated reporting is not
+  governed by these settings.
+- PostHog reports an 84-month, plan-derived event-retention window, but automated
+  enforcement is currently disabled. BugDrop therefore does not promise that PostHog
+  event data will be automatically deleted after 84 months.
+
+## Service Providers
+
+BugDrop relies on:
+
+- GitHub to host installations, Issues, and screenshot files
+- Cloudflare to operate the hosted API and deliver parts of bugdrop.dev
+- Vercel to deliver bugdrop.dev
+- Google Analytics and PostHog for website analytics
+- YouTube for the embedded demonstration video
+
+Each provider processes information under its own privacy terms.
 
 ## Self-Hosting
 
-BugDrop is fully open source and self-hostable. If you run your own instance, you control all data processing and can add your own WAF, CAPTCHA, logging, retention, and content filtering controls. See [SELF_HOSTING.md](./SELF_HOSTING.md) for instructions.
+BugDrop is open source and self-hostable. Self-hosted installations control their own data
+processing, storage, logging, analytics, security, and retention practices. This policy
+does not govern independent self-hosted deployments. See
+[SELF_HOSTING.md](./SELF_HOSTING.md) for instructions.
 
-## Contact
+## Your Choices
 
-For privacy questions, open an issue at [github.com/mean-weasel/bugdrop](https://github.com/mean-weasel/bugdrop).
+Installation owners may request access to, correction of, or deletion of their retained
+installation information. They may also decline outreach or withdraw permission to use
+their name, logo, link, or testimonial.
+
+To make a privacy request, email [privacy@bugdrop.dev](mailto:privacy@bugdrop.dev).
+
+## Changes to This Policy
+
+Material changes will be published before the related collection begins. The "Last
+updated" date will identify the latest revision.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -12,8 +12,9 @@ When someone submits feedback, BugDrop processes:
 
 - The submitted title, description, category, and optional attachments
 - A screenshot when the site configures screenshots as optional, automatic, or required;
-  automatic mode captures and attaches a full-page screenshot on submission without a
-  preview
+  automatic mode attempts to capture and attach a full-page screenshot on submission
+  without a preview, but a submission may proceed without one on very complex pages or if
+  capture fails
 - Browser, operating system, viewport, language, and page information
 - Recent console messages, timestamps, and source locations, only when the reporter chooses
   to include console logs

--- a/docs/website/faq.mdx
+++ b/docs/website/faq.mdx
@@ -175,16 +175,27 @@ If the GitHub API is unavailable when a user submits feedback, the BugDrop API w
 
 ### Does BugDrop track users?
 
-No. BugDrop does not set cookies, use local storage for tracking, send analytics, or fingerprint users. The only data sent to the server is the feedback form contents (title, description, category, optional screenshot, optional name/email, and automatically captured system information). This data goes directly to your GitHub repository and is not stored anywhere else.
+The widget does not track feedback reporters. It does not set analytics cookies, use
+browser storage to track reporters, send reporter analytics, or fingerprint users.
+Feedback form contents go to the hosted service only to create the requested GitHub Issue
+and associated files. BugDrop does not retain that content in a separate feedback
+database. The service does keep short-lived rate-limit counters and may retain limited
+installation and aggregate usage information.
+
+Separately, the bugdrop.dev website uses limited website analytics. See the
+[Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md) for details.
 
 ### Where is my data stored?
 
-All data is stored in your GitHub repository:
+Feedback data is stored in your GitHub repository:
 
 - **Issues** are created as GitHub Issues with labels and formatted bodies
 - **Screenshots** are committed to the `bugdrop-screenshots` branch in a `.bugdrop/` directory
 
-No data is stored on the Cloudflare Worker. The API is stateless -- it receives the form submission, creates the GitHub Issue, and discards the data.
+The API discards feedback content after creating the GitHub Issue and associated files.
+The hosted service separately keeps short-lived rate-limit counters and may retain the
+limited installation and aggregate usage information described in the
+[Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md).
 
 ### Can I self-host BugDrop?
 

--- a/docs/website/getting-started.mdx
+++ b/docs/website/getting-started.mdx
@@ -43,7 +43,7 @@ That is it. No servers to run, no databases to manage, no user accounts required
 - **JavaScript API** -- Programmatic control for advanced integrations
 - **Version pinning** -- Pin to major, minor, or patch versions for stability
 - **Rate limiting** -- Built-in protection against abuse
-- **Privacy-first** -- No user data stored on external servers
+- **Privacy-first** -- Feedback content is stored in GitHub, not in a separate BugDrop feedback database
 
 ## Quick Links
 

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -26,7 +26,11 @@ You can review and revoke the app's access at any time from your GitHub settings
 
 ## Data Storage
 
-BugDrop follows a "GitHub-native" storage model. All data stays within your GitHub repository -- nothing is stored on external servers.
+BugDrop follows a "GitHub-native" feedback-storage model. Feedback content and uploaded
+files are stored in your GitHub repository, not in a separate BugDrop feedback database.
+The hosted service temporarily stores rate-limit counters and may retain limited
+installation and aggregate usage information as described in the
+[Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md).
 
 ### Issues
 
@@ -70,7 +74,7 @@ BugDrop is built with a privacy-first approach:
 
 - **No user tracking** -- BugDrop does not set cookies, use local storage for tracking, or fingerprint users
 - **No analytics** -- The widget does not send any telemetry, usage data, or analytics to any server
-- **No external data storage** -- All data (issues and screenshots) is stored in your GitHub repository
+- **GitHub-native feedback storage** -- Issue content, screenshots, and attachments are stored in your GitHub repository rather than a separate BugDrop feedback database
 - **No user accounts** -- Users submitting feedback do not need to create accounts or log in
 - **No PII collection by default** -- Name and email fields are off by default. When enabled, this data goes only to the GitHub Issue in your repository
 - **Client-side screenshots** -- Screenshots are rendered in the user's browser, not captured server-side
@@ -86,8 +90,8 @@ covered:
 <input type="email" data-bugdrop-redact />
 
 <div data-bugdrop-mask>
-  <span>Customer name</span>
-  <span>customer@example.com</span>
+  <span>User name</span>
+  <span>user@example.com</span>
 </div>
 ```
 
@@ -142,7 +146,10 @@ The only network requests BugDrop makes are:
 1. Loading the widget script from Cloudflare Workers
 2. Submitting the feedback form to the BugDrop Cloudflare Worker API
 
-The API acts as a pass-through to the GitHub API -- it receives the form data, creates the issue and uploads the screenshot, and discards the data. Nothing is persisted on the Cloudflare Worker.
+The API receives the form data, creates the issue and uploads its files, then discards the
+feedback content. The hosted service separately keeps short-lived rate-limit counters; see
+the [Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md) for the
+complete data-handling and retention details.
 
 ## Rate Limiting
 


### PR DESCRIPTION
## Summary
- publish the reviewed privacy policy for the hosted widget, service, and bugdrop.dev
- disclose feedback handling, website analytics, temporary rate-limit data, and future installation analytics safeguards
- require explicit permission before using app names, links, logos, or testimonials
- align synced website documentation with the policy

## Verification
- `git diff --check`
- Prettier check for all changed Markdown/MDX files
- `vitest run test/securityPolicy.test.ts test/syncWebsiteDocs.test.ts` (13 tests passed)
- contradiction scan for superseded storage claims
- independent correctness, verification, and simplification reviews

## Follow-up
- identifiable installation analytics remain disabled until uninstall deletion and a verifiable cleanup backstop are implemented
- merging this PR will trigger the existing documentation sync workflow for bugdrop-web