### PR TITLE
Add installation deletion safeguards

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@ import { Hono } from 'hono';
 import { logger } from 'hono/logger';
 import type { Env } from './types';
 import api from './routes/api';
+import githubWebhook from './routes/github-webhook';
 import { createBoardDogfoodToken } from './lib/boardDogfood';
+import { sweepInstallationRecords } from './lib/installation-retention';
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -45,6 +47,7 @@ app.use('*', logger());
 
 // Mount API routes
 app.route('/api', api);
+app.route('/api', githubWebhook);
 
 export function isWeakAuthTokenSecret(secret?: string): boolean {
   return typeof secret === 'string' && secret.length > 0 && secret.length < 32;
@@ -141,4 +144,15 @@ function serveAsset(c: { env: Env; req: { raw: Request } }, pathname: string): P
   return c.env.ASSETS.fetch(new Request(url, c.req.raw));
 }
 
-export default app;
+export async function scheduled(
+  _controller: ScheduledController,
+  env: Env,
+  _ctx: ExecutionContext
+): Promise<void> {
+  await sweepInstallationRecords(env);
+}
+
+export default {
+  fetch: app.fetch,
+  scheduled,
+};

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,7 +1,7 @@
 import { generateGitHubAppJWT } from './jwt';
 import type { Env, FeedbackAttachment, GitHubIssue } from '../types';
 
-const GITHUB_API = 'https://api.github.com';
+export const GITHUB_API = 'https://api.github.com';
 
 /**
  * Thrown when GitHub rejects an issue creation specifically due to invalid
@@ -18,7 +18,7 @@ export class GitHubLabelError extends Error {
   }
 }
 
-const headers = (token: string) => ({
+export const githubHeaders = (token: string) => ({
   Authorization: `Bearer ${token}`,
   Accept: 'application/vnd.github+json',
   'Content-Type': 'application/json',
@@ -38,7 +38,7 @@ async function getInstallationId(env: Env, owner: string, repo: string): Promise
   const jwt = await generateGitHubAppJWT(env.GITHUB_APP_ID, env.GITHUB_PRIVATE_KEY);
 
   const response = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/installation`, {
-    headers: headers(jwt),
+    headers: githubHeaders(jwt),
   });
 
   if (!response.ok) {
@@ -65,7 +65,7 @@ export async function getInstallationToken(
 
   const response = await fetch(`${GITHUB_API}/app/installations/${installationId}/access_tokens`, {
     method: 'POST',
-    headers: headers(jwt),
+    headers: githubHeaders(jwt),
   });
 
   if (!response.ok) {
@@ -90,7 +90,7 @@ export async function createIssue(
 ): Promise<GitHubIssue> {
   const response = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/issues`, {
     method: 'POST',
-    headers: headers(token),
+    headers: githubHeaders(token),
     body: JSON.stringify({ title, body, labels }),
   });
 
@@ -128,7 +128,7 @@ function isLabelValidationFailure(body: string): boolean {
 export async function isRepoPublic(token: string, owner: string, repo: string): Promise<boolean> {
   try {
     const response = await fetch(`${GITHUB_API}/repos/${owner}/${repo}`, {
-      headers: headers(token),
+      headers: githubHeaders(token),
     });
 
     if (!response.ok) {
@@ -151,7 +151,7 @@ async function ensureScreenshotBranch(token: string, owner: string, repo: string
   // Check if branch already exists
   const check = await fetch(
     `${GITHUB_API}/repos/${owner}/${repo}/git/ref/heads/${SCREENSHOT_BRANCH}`,
-    { headers: headers(token) }
+    { headers: githubHeaders(token) }
   );
   if (check.ok) return;
   if (check.status !== 404) {
@@ -160,7 +160,7 @@ async function ensureScreenshotBranch(token: string, owner: string, repo: string
 
   // Get default branch SHA
   const repoRes = await fetch(`${GITHUB_API}/repos/${owner}/${repo}`, {
-    headers: headers(token),
+    headers: githubHeaders(token),
   });
   if (!repoRes.ok) {
     throw new Error(`Failed to get repo info: ${repoRes.status}`);
@@ -169,7 +169,7 @@ async function ensureScreenshotBranch(token: string, owner: string, repo: string
 
   const refRes = await fetch(
     `${GITHUB_API}/repos/${owner}/${repo}/git/ref/heads/${repoData.default_branch}`,
-    { headers: headers(token) }
+    { headers: githubHeaders(token) }
   );
   if (!refRes.ok) {
     throw new Error(`Failed to get default branch ref: ${refRes.status}`);
@@ -179,7 +179,7 @@ async function ensureScreenshotBranch(token: string, owner: string, repo: string
   // Create the screenshot branch
   const createRes = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/git/refs`, {
     method: 'POST',
-    headers: headers(token),
+    headers: githubHeaders(token),
     body: JSON.stringify({
       ref: `refs/heads/${SCREENSHOT_BRANCH}`,
       sha: refData.object.sha,
@@ -190,7 +190,7 @@ async function ensureScreenshotBranch(token: string, owner: string, repo: string
     if (createRes.status === 422 && isExistingReferenceError(error)) {
       const recheck = await fetch(
         `${GITHUB_API}/repos/${owner}/${repo}/git/ref/heads/${SCREENSHOT_BRANCH}`,
-        { headers: headers(token) }
+        { headers: githubHeaders(token) }
       );
       if (recheck.ok) return;
     }
@@ -271,7 +271,7 @@ async function uploadBase64Asset(
 
   const response = await fetch(`${GITHUB_API}/repos/${owner}/${repo}/contents/${filename}`, {
     method: 'PUT',
-    headers: headers(token),
+    headers: githubHeaders(token),
     body: JSON.stringify({
       message,
       content: content,

--- a/src/lib/installation-cleanup-state.ts
+++ b/src/lib/installation-cleanup-state.ts
@@ -6,7 +6,7 @@ export interface InstallationCleanupAudit {
   deletedCount: number;
 }
 
-export interface InstallationScanningCheckpoint {
+interface InstallationScanningCheckpoint {
   schemaVersion: 1;
   phase: 'scanning';
   cursor: string;
@@ -15,7 +15,7 @@ export interface InstallationScanningCheckpoint {
   deletedCount: number;
 }
 
-export interface InstallationFinalizingCheckpoint {
+interface InstallationFinalizingCheckpoint {
   schemaVersion: 1;
   phase: 'finalizing';
   audit: InstallationCleanupAudit;

--- a/src/lib/installation-cleanup-state.ts
+++ b/src/lib/installation-cleanup-state.ts
@@ -1,0 +1,127 @@
+export interface InstallationCleanupAudit {
+  schemaVersion: 1;
+  completedAt: string;
+  scannedCount: number;
+  activeCount: number;
+  deletedCount: number;
+}
+
+export interface InstallationScanningCheckpoint {
+  schemaVersion: 1;
+  phase: 'scanning';
+  cursor: string;
+  startedAt: string;
+  scannedCount: number;
+  deletedCount: number;
+}
+
+export interface InstallationFinalizingCheckpoint {
+  schemaVersion: 1;
+  phase: 'finalizing';
+  audit: InstallationCleanupAudit;
+}
+
+export type InstallationStableCheckpoint =
+  InstallationScanningCheckpoint | InstallationFinalizingCheckpoint;
+
+export interface InstallationDeletingCheckpoint {
+  schemaVersion: 1;
+  phase: 'deleting';
+  installationIds: number[];
+  next: InstallationStableCheckpoint;
+}
+
+export type InstallationCleanupCheckpoint =
+  InstallationStableCheckpoint | InstallationDeletingCheckpoint;
+
+export function parseInstallationCleanupCheckpoint(
+  value: string | null
+): InstallationCleanupCheckpoint | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Record<string, unknown>;
+    if (parsed.schemaVersion !== 1) throw new Error('invalid schema');
+
+    const stableCheckpoint = parseStableCheckpoint(parsed);
+    if (stableCheckpoint) return stableCheckpoint;
+
+    if (
+      parsed.phase === 'deleting' &&
+      Array.isArray(parsed.installationIds) &&
+      parsed.installationIds.length > 0 &&
+      parsed.installationIds.every(isInstallationId) &&
+      parsed.next &&
+      typeof parsed.next === 'object'
+    ) {
+      const next = parseStableCheckpoint(parsed.next as Record<string, unknown>);
+      if (next) {
+        return {
+          schemaVersion: 1,
+          phase: 'deleting',
+          installationIds: parsed.installationIds,
+          next,
+        };
+      }
+    }
+
+    throw new Error('invalid checkpoint fields');
+  } catch {
+    throw new Error('Malformed installation cleanup checkpoint');
+  }
+}
+
+function parseStableCheckpoint(
+  parsed: Record<string, unknown>
+): InstallationStableCheckpoint | null {
+  if (parsed.schemaVersion !== 1) return null;
+
+  if (parsed.phase === 'finalizing' && isAudit(parsed.audit)) {
+    return {
+      schemaVersion: 1,
+      phase: 'finalizing',
+      audit: parsed.audit,
+    };
+  }
+
+  if (
+    parsed.phase === 'scanning' &&
+    typeof parsed.cursor === 'string' &&
+    parsed.cursor &&
+    typeof parsed.startedAt === 'string' &&
+    isCount(parsed.scannedCount) &&
+    isCount(parsed.deletedCount) &&
+    parsed.deletedCount <= parsed.scannedCount
+  ) {
+    return {
+      schemaVersion: 1,
+      phase: 'scanning',
+      cursor: parsed.cursor,
+      startedAt: parsed.startedAt,
+      scannedCount: parsed.scannedCount,
+      deletedCount: parsed.deletedCount,
+    };
+  }
+
+  return null;
+}
+
+function isAudit(value: unknown): value is InstallationCleanupAudit {
+  if (!value || typeof value !== 'object') return false;
+  const audit = value as Record<string, unknown>;
+  return (
+    audit.schemaVersion === 1 &&
+    typeof audit.completedAt === 'string' &&
+    isCount(audit.scannedCount) &&
+    isCount(audit.activeCount) &&
+    isCount(audit.deletedCount) &&
+    audit.deletedCount <= audit.scannedCount
+  );
+}
+
+function isCount(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isInstallationId(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}

--- a/src/lib/installation-retention.ts
+++ b/src/lib/installation-retention.ts
@@ -1,0 +1,277 @@
+import { generateGitHubAppJWT } from './jwt';
+import { GITHUB_API, githubHeaders } from './github';
+import type { Env } from '../types';
+
+const INSTALLATION_RECORD_PREFIX = 'installation:';
+const GITHUB_PAGE_SIZE = 100;
+export const MAX_GITHUB_INSTALLATION_PAGES = 20;
+export const INSTALLATION_SWEEP_PAGE_SIZE = 25;
+export const MAX_CONCURRENT_CLEANUP_OPERATIONS = 6;
+
+export const INSTALLATION_CLEANUP_AUDIT_KEY = 'operations:installation-cleanup:last-success';
+export const INSTALLATION_CLEANUP_CHECKPOINT_KEY = 'operations:installation-cleanup:checkpoint';
+
+export interface InstallationCleanupAudit {
+  schemaVersion: 1;
+  completedAt: string;
+  scannedCount: number;
+  activeCount: number;
+  deletedCount: number;
+}
+
+interface GitHubListOptions {
+  fetchImpl?: typeof fetch;
+  createJwt?: (appId: string, privateKey: string) => Promise<string>;
+}
+
+interface InstallationSweepOptions {
+  now?: Date;
+  listActiveInstallationIds?: (env: Env) => Promise<Set<number>>;
+  confirmInstallationIsInactive?: (env: Env, installationId: number) => Promise<boolean>;
+}
+
+interface InstallationCleanupCheckpoint {
+  schemaVersion: 1;
+  cursor: string;
+  startedAt: string;
+  scannedCount: number;
+  deletedCount: number;
+}
+
+export function installationRecordKey(installationId: number): string {
+  if (!Number.isSafeInteger(installationId) || installationId <= 0) {
+    throw new Error('Invalid installation ID');
+  }
+  return `${INSTALLATION_RECORD_PREFIX}${installationId}`;
+}
+
+export async function deleteInstallationRecord(
+  store: KVNamespace,
+  installationId: number
+): Promise<void> {
+  await store.delete(installationRecordKey(installationId));
+}
+
+export async function verifyGitHubWebhookSignature(
+  secret: string,
+  signatureHeader: string | undefined,
+  body: string
+): Promise<boolean> {
+  if (!secret || !signatureHeader?.startsWith('sha256=')) return false;
+
+  const supplied = hexToBytes(signatureHeader.slice('sha256='.length));
+  if (!supplied) return false;
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['verify']
+  );
+  return crypto.subtle.verify('HMAC', key, supplied, new TextEncoder().encode(body));
+}
+
+export async function listActiveGitHubInstallationIds(
+  env: Env,
+  options: GitHubListOptions = {}
+): Promise<Set<number>> {
+  if (!env.GITHUB_APP_ID || !env.GITHUB_PRIVATE_KEY) {
+    throw new Error('GitHub App credentials are required for installation cleanup');
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const createJwt = options.createJwt ?? generateGitHubAppJWT;
+  const jwt = await createJwt(env.GITHUB_APP_ID, env.GITHUB_PRIVATE_KEY);
+  const activeIds = new Set<number>();
+
+  for (let page = 1; page <= MAX_GITHUB_INSTALLATION_PAGES; page += 1) {
+    const response = await fetchImpl(
+      `${GITHUB_API}/app/installations?per_page=${GITHUB_PAGE_SIZE}&page=${page}`,
+      {
+        headers: githubHeaders(jwt),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to list GitHub App installations: ${response.status}`);
+    }
+
+    const installations = (await response.json()) as unknown;
+    if (!Array.isArray(installations)) {
+      throw new Error('GitHub returned an invalid installation list');
+    }
+
+    for (const installation of installations) {
+      const id = installationIdFromGitHub(installation);
+      activeIds.add(id);
+    }
+
+    if (installations.length < GITHUB_PAGE_SIZE) return activeIds;
+  }
+
+  throw new Error('GitHub installation pagination exceeded the safety limit');
+}
+
+export async function confirmGitHubInstallationIsInactive(
+  env: Env,
+  installationId: number,
+  options: GitHubListOptions = {}
+): Promise<boolean> {
+  if (!env.GITHUB_APP_ID || !env.GITHUB_PRIVATE_KEY) {
+    throw new Error('GitHub App credentials are required for installation cleanup');
+  }
+  installationRecordKey(installationId);
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const createJwt = options.createJwt ?? generateGitHubAppJWT;
+  const jwt = await createJwt(env.GITHUB_APP_ID, env.GITHUB_PRIVATE_KEY);
+  const response = await fetchImpl(`${GITHUB_API}/app/installations/${installationId}`, {
+    headers: githubHeaders(jwt),
+  });
+  if (response.body) await response.body.cancel();
+
+  if (response.ok) return false;
+  if (response.status === 404) return true;
+  throw new Error(`Failed to confirm GitHub App installation: ${response.status}`);
+}
+
+export async function sweepInstallationRecords(
+  env: Env,
+  options: InstallationSweepOptions = {}
+): Promise<InstallationCleanupAudit | null> {
+  const store = env.INSTALLATION_ANALYTICS;
+  if (!store) throw new Error('INSTALLATION_ANALYTICS binding is required for cleanup');
+
+  const now = options.now ?? new Date();
+  const checkpoint = parseCheckpoint(await store.get(INSTALLATION_CLEANUP_CHECKPOINT_KEY));
+  const listActive = options.listActiveInstallationIds ?? listActiveGitHubInstallationIds;
+  const activeIds = await listActive(env);
+  const storedPage = await listStoredInstallationPage(store, checkpoint?.cursor);
+  const staleIds = storedPage.ids.filter(id => !activeIds.has(id));
+  let confirmInactive = options.confirmInstallationIsInactive;
+  if (!confirmInactive && staleIds.length > 0) {
+    if (!env.GITHUB_APP_ID || !env.GITHUB_PRIVATE_KEY) {
+      throw new Error('GitHub App credentials are required for installation cleanup');
+    }
+    const jwt = await generateGitHubAppJWT(env.GITHUB_APP_ID, env.GITHUB_PRIVATE_KEY);
+    confirmInactive = (candidateEnv, installationId) =>
+      confirmGitHubInstallationIsInactive(candidateEnv, installationId, {
+        createJwt: async () => jwt,
+      });
+  }
+  const inactiveResults = confirmInactive
+    ? await mapInBatches(staleIds, id => confirmInactive(env, id))
+    : [];
+  const confirmedInactiveIds = staleIds.filter((_id, index) => inactiveResults[index]);
+
+  await mapInBatches(confirmedInactiveIds, id => deleteInstallationRecord(store, id));
+
+  const scannedCount = (checkpoint?.scannedCount ?? 0) + storedPage.ids.length;
+  const deletedCount = (checkpoint?.deletedCount ?? 0) + confirmedInactiveIds.length;
+  if (storedPage.cursor) {
+    const nextCheckpoint: InstallationCleanupCheckpoint = {
+      schemaVersion: 1,
+      cursor: storedPage.cursor,
+      startedAt: checkpoint?.startedAt ?? now.toISOString(),
+      scannedCount,
+      deletedCount,
+    };
+    await store.put(INSTALLATION_CLEANUP_CHECKPOINT_KEY, JSON.stringify(nextCheckpoint));
+    return null;
+  }
+
+  const audit: InstallationCleanupAudit = {
+    schemaVersion: 1,
+    completedAt: now.toISOString(),
+    scannedCount,
+    activeCount: activeIds.size,
+    deletedCount,
+  };
+  await store.delete(INSTALLATION_CLEANUP_CHECKPOINT_KEY);
+  await store.put(INSTALLATION_CLEANUP_AUDIT_KEY, JSON.stringify(audit));
+  return audit;
+}
+
+async function listStoredInstallationPage(
+  store: KVNamespace,
+  cursor?: string
+): Promise<{ ids: number[]; cursor?: string }> {
+  const ids: number[] = [];
+  const page = await store.list({
+    prefix: INSTALLATION_RECORD_PREFIX,
+    limit: INSTALLATION_SWEEP_PAGE_SIZE,
+    ...(cursor ? { cursor } : {}),
+  });
+  for (const key of page.keys) {
+    const rawId = key.name.slice(INSTALLATION_RECORD_PREFIX.length);
+    if (!/^\d+$/.test(rawId)) {
+      throw new Error(`Malformed installation record key: ${key.name}`);
+    }
+    const id = Number(rawId);
+    if (!Number.isSafeInteger(id) || id <= 0) {
+      throw new Error(`Malformed installation record key: ${key.name}`);
+    }
+    ids.push(id);
+  }
+  if (!page.list_complete && !page.cursor) {
+    throw new Error('Installation record pagination omitted its cursor');
+  }
+
+  return { ids, ...(page.list_complete ? {} : { cursor: page.cursor }) };
+}
+
+function parseCheckpoint(value: string | null): InstallationCleanupCheckpoint | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<InstallationCleanupCheckpoint>;
+    if (
+      parsed.schemaVersion !== 1 ||
+      typeof parsed.cursor !== 'string' ||
+      !parsed.cursor ||
+      typeof parsed.startedAt !== 'string' ||
+      !Number.isSafeInteger(parsed.scannedCount) ||
+      !Number.isSafeInteger(parsed.deletedCount) ||
+      (parsed.scannedCount ?? -1) < 0 ||
+      (parsed.deletedCount ?? -1) < 0 ||
+      (parsed.deletedCount ?? 0) > (parsed.scannedCount ?? -1)
+    ) {
+      throw new Error('invalid checkpoint fields');
+    }
+    return parsed as InstallationCleanupCheckpoint;
+  } catch {
+    throw new Error('Malformed installation cleanup checkpoint');
+  }
+}
+
+function installationIdFromGitHub(value: unknown): number {
+  if (!value || typeof value !== 'object' || !('id' in value)) {
+    throw new Error('GitHub returned an invalid installation record');
+  }
+  const id = (value as { id: unknown }).id;
+  if (typeof id !== 'number' || !Number.isSafeInteger(id) || id <= 0) {
+    throw new Error('GitHub returned an invalid installation ID');
+  }
+  return id;
+}
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (!/^[0-9a-f]{64}$/i.test(hex)) return null;
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+async function mapInBatches<T, Result>(
+  values: T[],
+  callback: (value: T) => Promise<Result>
+): Promise<Result[]> {
+  const results: Result[] = [];
+  for (let offset = 0; offset < values.length; offset += MAX_CONCURRENT_CLEANUP_OPERATIONS) {
+    const batch = values.slice(offset, offset + MAX_CONCURRENT_CLEANUP_OPERATIONS);
+    results.push(...(await Promise.all(batch.map(callback))));
+  }
+  return results;
+}

--- a/src/lib/installation-retention.ts
+++ b/src/lib/installation-retention.ts
@@ -1,6 +1,14 @@
 import { generateGitHubAppJWT } from './jwt';
 import { GITHUB_API, githubHeaders } from './github';
+import {
+  parseInstallationCleanupCheckpoint,
+  type InstallationCleanupAudit,
+  type InstallationDeletingCheckpoint,
+  type InstallationStableCheckpoint,
+} from './installation-cleanup-state';
 import type { Env } from '../types';
+
+export type { InstallationCleanupAudit } from './installation-cleanup-state';
 
 const INSTALLATION_RECORD_PREFIX = 'installation:';
 const GITHUB_PAGE_SIZE = 100;
@@ -11,14 +19,6 @@ export const MAX_CONCURRENT_CLEANUP_OPERATIONS = 6;
 export const INSTALLATION_CLEANUP_AUDIT_KEY = 'operations:installation-cleanup:last-success';
 export const INSTALLATION_CLEANUP_CHECKPOINT_KEY = 'operations:installation-cleanup:checkpoint';
 
-export interface InstallationCleanupAudit {
-  schemaVersion: 1;
-  completedAt: string;
-  scannedCount: number;
-  activeCount: number;
-  deletedCount: number;
-}
-
 interface GitHubListOptions {
   fetchImpl?: typeof fetch;
   createJwt?: (appId: string, privateKey: string) => Promise<string>;
@@ -28,14 +28,6 @@ interface InstallationSweepOptions {
   now?: Date;
   listActiveInstallationIds?: (env: Env) => Promise<Set<number>>;
   confirmInstallationIsInactive?: (env: Env, installationId: number) => Promise<boolean>;
-}
-
-interface InstallationCleanupCheckpoint {
-  schemaVersion: 1;
-  cursor: string;
-  startedAt: string;
-  scannedCount: number;
-  deletedCount: number;
 }
 
 export function installationRecordKey(installationId: number): string {
@@ -144,7 +136,15 @@ export async function sweepInstallationRecords(
   if (!store) throw new Error('INSTALLATION_ANALYTICS binding is required for cleanup');
 
   const now = options.now ?? new Date();
-  const checkpoint = parseCheckpoint(await store.get(INSTALLATION_CLEANUP_CHECKPOINT_KEY));
+  const checkpoint = parseInstallationCleanupCheckpoint(
+    await store.get(INSTALLATION_CLEANUP_CHECKPOINT_KEY)
+  );
+  if (checkpoint?.phase === 'finalizing') {
+    return publishFinalAudit(store, checkpoint.audit);
+  }
+  if (checkpoint?.phase === 'deleting') {
+    return finishDeletionBatch(store, checkpoint);
+  }
   const listActive = options.listActiveInstallationIds ?? listActiveGitHubInstallationIds;
   const activeIds = await listActive(env);
   const storedPage = await listStoredInstallationPage(store, checkpoint?.cursor);
@@ -165,31 +165,67 @@ export async function sweepInstallationRecords(
     : [];
   const confirmedInactiveIds = staleIds.filter((_id, index) => inactiveResults[index]);
 
-  await mapInBatches(confirmedInactiveIds, id => deleteInstallationRecord(store, id));
-
   const scannedCount = (checkpoint?.scannedCount ?? 0) + storedPage.ids.length;
   const deletedCount = (checkpoint?.deletedCount ?? 0) + confirmedInactiveIds.length;
+  let nextCheckpoint: InstallationStableCheckpoint;
   if (storedPage.cursor) {
-    const nextCheckpoint: InstallationCleanupCheckpoint = {
+    nextCheckpoint = {
       schemaVersion: 1,
+      phase: 'scanning',
       cursor: storedPage.cursor,
       startedAt: checkpoint?.startedAt ?? now.toISOString(),
       scannedCount,
       deletedCount,
     };
-    await store.put(INSTALLATION_CLEANUP_CHECKPOINT_KEY, JSON.stringify(nextCheckpoint));
-    return null;
+  } else {
+    nextCheckpoint = {
+      schemaVersion: 1,
+      phase: 'finalizing',
+      audit: {
+        schemaVersion: 1,
+        completedAt: now.toISOString(),
+        scannedCount,
+        activeCount: activeIds.size,
+        deletedCount,
+      },
+    };
   }
 
-  const audit: InstallationCleanupAudit = {
+  if (confirmedInactiveIds.length === 0) return advanceCheckpoint(store, nextCheckpoint);
+
+  const deletingCheckpoint: InstallationDeletingCheckpoint = {
     schemaVersion: 1,
-    completedAt: now.toISOString(),
-    scannedCount,
-    activeCount: activeIds.size,
-    deletedCount,
+    phase: 'deleting',
+    installationIds: confirmedInactiveIds,
+    next: nextCheckpoint,
   };
-  await store.delete(INSTALLATION_CLEANUP_CHECKPOINT_KEY);
+  await store.put(INSTALLATION_CLEANUP_CHECKPOINT_KEY, JSON.stringify(deletingCheckpoint));
+  return finishDeletionBatch(store, deletingCheckpoint);
+}
+
+async function finishDeletionBatch(
+  store: KVNamespace,
+  checkpoint: InstallationDeletingCheckpoint
+): Promise<InstallationCleanupAudit | null> {
+  await mapInBatches(checkpoint.installationIds, id => deleteInstallationRecord(store, id));
+  return advanceCheckpoint(store, checkpoint.next);
+}
+
+async function advanceCheckpoint(
+  store: KVNamespace,
+  checkpoint: InstallationStableCheckpoint
+): Promise<InstallationCleanupAudit | null> {
+  await store.put(INSTALLATION_CLEANUP_CHECKPOINT_KEY, JSON.stringify(checkpoint));
+  if (checkpoint.phase === 'scanning') return null;
+  return publishFinalAudit(store, checkpoint.audit);
+}
+
+async function publishFinalAudit(
+  store: KVNamespace,
+  audit: InstallationCleanupAudit
+): Promise<InstallationCleanupAudit> {
   await store.put(INSTALLATION_CLEANUP_AUDIT_KEY, JSON.stringify(audit));
+  await store.delete(INSTALLATION_CLEANUP_CHECKPOINT_KEY);
   return audit;
 }
 
@@ -219,29 +255,6 @@ async function listStoredInstallationPage(
   }
 
   return { ids, ...(page.list_complete ? {} : { cursor: page.cursor }) };
-}
-
-function parseCheckpoint(value: string | null): InstallationCleanupCheckpoint | null {
-  if (!value) return null;
-  try {
-    const parsed = JSON.parse(value) as Partial<InstallationCleanupCheckpoint>;
-    if (
-      parsed.schemaVersion !== 1 ||
-      typeof parsed.cursor !== 'string' ||
-      !parsed.cursor ||
-      typeof parsed.startedAt !== 'string' ||
-      !Number.isSafeInteger(parsed.scannedCount) ||
-      !Number.isSafeInteger(parsed.deletedCount) ||
-      (parsed.scannedCount ?? -1) < 0 ||
-      (parsed.deletedCount ?? -1) < 0 ||
-      (parsed.deletedCount ?? 0) > (parsed.scannedCount ?? -1)
-    ) {
-      throw new Error('invalid checkpoint fields');
-    }
-    return parsed as InstallationCleanupCheckpoint;
-  } catch {
-    throw new Error('Malformed installation cleanup checkpoint');
-  }
 }
 
 function installationIdFromGitHub(value: unknown): number {

--- a/src/routes/github-webhook.ts
+++ b/src/routes/github-webhook.ts
@@ -1,0 +1,76 @@
+import { Hono } from 'hono';
+import type { Env } from '../types';
+import {
+  deleteInstallationRecord,
+  verifyGitHubWebhookSignature,
+} from '../lib/installation-retention';
+
+const githubWebhook = new Hono<{ Bindings: Env }>();
+
+githubWebhook.post('/github/webhook', async c => {
+  const secret = c.env.GITHUB_WEBHOOK_SECRET;
+  if (!secret) {
+    return c.json({ error: 'GitHub webhook is not configured' }, 503);
+  }
+
+  const body = await c.req.text();
+  const signatureIsValid = await verifyGitHubWebhookSignature(
+    secret,
+    c.req.header('x-hub-signature-256'),
+    body
+  );
+  if (!signatureIsValid) {
+    return c.json({ error: 'Invalid webhook signature' }, 401);
+  }
+
+  const event = c.req.header('x-github-event');
+  if (!event) {
+    return c.json({ error: 'Missing GitHub event type' }, 400);
+  }
+  if (event !== 'installation') {
+    return c.json({ accepted: true }, 202);
+  }
+
+  const payload = parseInstallationPayload(body);
+  if (!payload) {
+    return c.json({ error: 'Invalid installation webhook payload' }, 400);
+  }
+  if (payload.action !== 'deleted') {
+    return c.json({ accepted: true }, 202);
+  }
+
+  const store = c.env.INSTALLATION_ANALYTICS;
+  if (!store) {
+    return c.json({ error: 'Installation deletion storage is unavailable' }, 503);
+  }
+
+  await deleteInstallationRecord(store, payload.installation.id);
+  return c.json({ deleted: true }, 200);
+});
+
+function parseInstallationPayload(
+  body: string
+): { action: string; installation: { id: number } } | null {
+  try {
+    const payload = JSON.parse(body) as unknown;
+    if (!payload || typeof payload !== 'object') return null;
+    const candidate = payload as {
+      action?: unknown;
+      installation?: { id?: unknown };
+    };
+    const id = candidate.installation?.id;
+    if (
+      typeof candidate.action !== 'string' ||
+      typeof id !== 'number' ||
+      !Number.isSafeInteger(id) ||
+      id <= 0
+    ) {
+      return null;
+    }
+    return { action: candidate.action, installation: { id } };
+  } catch {
+    return null;
+  }
+}
+
+export default githubWebhook;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export interface Env {
   // Secrets (from .dev.vars locally, wrangler secret in production)
   GITHUB_APP_ID: string;
   GITHUB_PRIVATE_KEY: string;
+  GITHUB_WEBHOOK_SECRET?: string; // HMAC secret for authenticated GitHub App webhooks
 
   // Variables (from wrangler.toml)
   ENVIRONMENT: string;
@@ -28,6 +29,7 @@ export interface Env {
   // Bindings
   ASSETS: Fetcher;
   RATE_LIMIT?: KVNamespace; // Optional: for rate limiting (create with wrangler kv:namespace create RATE_LIMIT)
+  INSTALLATION_ANALYTICS?: KVNamespace; // Deletion-ready installation records; collection remains disabled
 }
 
 export type FeedbackCategory = 'bug' | 'feature' | 'question';

--- a/test/installationCleanupDurability.test.ts
+++ b/test/installationCleanupDurability.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/types';
+import {
+  INSTALLATION_CLEANUP_AUDIT_KEY,
+  INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+  sweepInstallationRecords,
+} from '../src/lib/installation-retention';
+
+const baseEnv = {
+  GITHUB_APP_ID: '123',
+  GITHUB_PRIVATE_KEY: 'test-private-key',
+} as Env;
+
+function createStore(overrides: Partial<KVNamespace> = {}): KVNamespace {
+  return {
+    delete: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null),
+    getWithMetadata: vi.fn(),
+    list: vi.fn().mockResolvedValue({
+      keys: [{ name: 'installation:3' }],
+      list_complete: true,
+      cacheStatus: null,
+    }),
+    put: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as KVNamespace;
+}
+
+function cleanupStates() {
+  const audit = {
+    schemaVersion: 1 as const,
+    completedAt: '2026-08-28T12:00:00.000Z',
+    scannedCount: 1,
+    activeCount: 0,
+    deletedCount: 1,
+  };
+  const finalizing = { schemaVersion: 1 as const, phase: 'finalizing' as const, audit };
+  const deleting = {
+    schemaVersion: 1 as const,
+    phase: 'deleting' as const,
+    installationIds: [3],
+    next: finalizing,
+  };
+  return { audit, deleting, finalizing };
+}
+
+function createOptions() {
+  return {
+    now: new Date('2026-08-28T12:00:00.000Z'),
+    listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()),
+    confirmInstallationIsInactive: vi.fn().mockResolvedValue(true),
+  };
+}
+
+describe('installation cleanup durability', () => {
+  it('never records a successful sweep when GitHub or deletion fails', async () => {
+    const githubFailureStore = createStore();
+    await expect(
+      sweepInstallationRecords(
+        { ...baseEnv, INSTALLATION_ANALYTICS: githubFailureStore },
+        { listActiveInstallationIds: vi.fn().mockRejectedValue(new Error('GitHub unavailable')) }
+      )
+    ).rejects.toThrow('GitHub unavailable');
+    expect(githubFailureStore.delete).not.toHaveBeenCalled();
+    expect(githubFailureStore.put).not.toHaveBeenCalled();
+
+    const deletionFailureStore = createStore({
+      delete: vi.fn().mockRejectedValue(new Error('KV deletion failed')),
+    });
+    await expect(
+      sweepInstallationRecords(
+        { ...baseEnv, INSTALLATION_ANALYTICS: deletionFailureStore },
+        createOptions()
+      )
+    ).rejects.toThrow('KV deletion failed');
+    expect(deletionFailureStore.put).toHaveBeenCalledExactlyOnceWith(
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      expect.stringContaining('"phase":"deleting"')
+    );
+    expect(deletionFailureStore.put).not.toHaveBeenCalledWith(
+      INSTALLATION_CLEANUP_AUDIT_KEY,
+      expect.anything()
+    );
+  });
+
+  it('does not delete records unless the pending deletion is durable', async () => {
+    const store = createStore({ put: vi.fn().mockRejectedValue(new Error('KV unavailable')) });
+    const options = createOptions();
+
+    await expect(
+      sweepInstallationRecords({ ...baseEnv, INSTALLATION_ANALYTICS: store }, options)
+    ).rejects.toThrow('KV unavailable');
+
+    expect(store.delete).not.toHaveBeenCalled();
+  });
+
+  it('replays a deletion when advancing to finalization fails', async () => {
+    const { audit, deleting, finalizing } = cleanupStates();
+    const options = createOptions();
+    const store = createStore({
+      get: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify(deleting)),
+      put: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('checkpoint unavailable'))
+        .mockResolvedValue(undefined),
+    });
+
+    await expect(
+      sweepInstallationRecords({ ...baseEnv, INSTALLATION_ANALYTICS: store }, options)
+    ).rejects.toThrow('checkpoint unavailable');
+    const result = await sweepInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      options
+    );
+
+    expect(result).toEqual(audit);
+    expect(options.listActiveInstallationIds).toHaveBeenCalledTimes(1);
+    expect(store.list).toHaveBeenCalledTimes(1);
+    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation:3');
+    expect(store.delete).toHaveBeenNthCalledWith(2, 'installation:3');
+    expect(store.put).toHaveBeenNthCalledWith(
+      3,
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      JSON.stringify(finalizing)
+    );
+    expect(store.put).toHaveBeenNthCalledWith(
+      4,
+      INSTALLATION_CLEANUP_AUDIT_KEY,
+      JSON.stringify(audit)
+    );
+  });
+
+  it('retries the exact final audit after publication fails without rescanning', async () => {
+    const { audit, deleting, finalizing } = cleanupStates();
+    const options = createOptions();
+    const store = createStore({
+      get: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify(finalizing)),
+      put: vi
+        .fn()
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('audit unavailable'))
+        .mockResolvedValueOnce(undefined),
+    });
+
+    await expect(
+      sweepInstallationRecords({ ...baseEnv, INSTALLATION_ANALYTICS: store }, options)
+    ).rejects.toThrow('audit unavailable');
+    const result = await sweepInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      options
+    );
+
+    expect(result).toEqual(audit);
+    expect(store.list).toHaveBeenCalledTimes(1);
+    expect(store.put).toHaveBeenNthCalledWith(
+      1,
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      JSON.stringify(deleting)
+    );
+    expect(store.put).toHaveBeenNthCalledWith(
+      4,
+      INSTALLATION_CLEANUP_AUDIT_KEY,
+      JSON.stringify(audit)
+    );
+    expect(store.delete).toHaveBeenLastCalledWith(INSTALLATION_CLEANUP_CHECKPOINT_KEY);
+  });
+});

--- a/test/installationCleanupScale.test.ts
+++ b/test/installationCleanupScale.test.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import worker from '../src/index';
 import type { Env } from '../src/types';
@@ -129,10 +128,17 @@ describe('installation cleanup boundaries', () => {
     expect(confirmInstallationIsInactive).toHaveBeenCalledTimes(INSTALLATION_SWEEP_PAGE_SIZE);
     expect(peakConfirmations).toBe(MAX_CONCURRENT_CLEANUP_OPERATIONS);
     expect(MAX_GITHUB_INSTALLATION_PAGES + INSTALLATION_SWEEP_PAGE_SIZE).toBeLessThanOrEqual(50);
-    expect(store.put).toHaveBeenCalledExactlyOnceWith(
+    expect(store.put).toHaveBeenNthCalledWith(
+      1,
       INSTALLATION_CLEANUP_CHECKPOINT_KEY,
-      expect.stringContaining('"cursor":"page-2"')
+      expect.stringContaining('"phase":"deleting"')
     );
+    expect(store.put).toHaveBeenNthCalledWith(
+      2,
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      expect.stringContaining('"phase":"scanning"')
+    );
+    expect(store.put).toHaveBeenCalledTimes(2);
     expect(store.put).not.toHaveBeenCalledWith(INSTALLATION_CLEANUP_AUDIT_KEY, expect.anything());
   });
 
@@ -184,6 +190,7 @@ describe('installation cleanup boundaries', () => {
   it('fails closed on a malformed cleanup checkpoint', async () => {
     const impossibleCheckpoint = {
       schemaVersion: 1,
+      phase: 'scanning',
       cursor: 'page-2',
       startedAt: '2026-08-28T12:00:00.000Z',
       scannedCount: 0,
@@ -223,16 +230,5 @@ describe('installation cleanup boundaries', () => {
 
     expect(response.status).toBe(200);
     expect(store.delete).toHaveBeenCalledExactlyOnceWith('installation:42');
-  });
-
-  it('binds isolated storage, the first-party route, and daily cleanup triggers', () => {
-    const config = readFileSync('wrangler.toml', 'utf8');
-
-    expect(config.match(/binding = "INSTALLATION_ANALYTICS"/g)).toHaveLength(3);
-    expect(config.match(/crons = \["17 3 \* \* \*"\]/g)).toHaveLength(2);
-    expect(config.match(/bugdrop\.dev\/api\/github\/webhook\*/g)).toHaveLength(2);
-    expect(config.indexOf('routes = [')).toBeLessThan(config.indexOf('[triggers]'));
-    expect(config).toContain('id = "a567f723a2eb4cfab807b0c1d678dc76"');
-    expect(config).toContain('id = "c58b33f6a0dc416b8661661ce0d23f7f"');
   });
 });

--- a/test/installationCleanupScale.test.ts
+++ b/test/installationCleanupScale.test.ts
@@ -1,0 +1,238 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import worker from '../src/index';
+import type { Env } from '../src/types';
+import {
+  INSTALLATION_CLEANUP_AUDIT_KEY,
+  INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+  INSTALLATION_SWEEP_PAGE_SIZE,
+  MAX_CONCURRENT_CLEANUP_OPERATIONS,
+  MAX_GITHUB_INSTALLATION_PAGES,
+  confirmGitHubInstallationIsInactive,
+  deleteInstallationRecord,
+  installationRecordKey,
+  sweepInstallationRecords,
+} from '../src/lib/installation-retention';
+
+const baseEnv: Env = {
+  GITHUB_APP_ID: '123',
+  GITHUB_PRIVATE_KEY: 'test-private-key',
+  GITHUB_WEBHOOK_SECRET: 'webhook-secret',
+  ENVIRONMENT: 'test',
+  ALLOWED_ORIGINS: '*',
+  GITHUB_APP_NAME: 'test-bugdrop-app',
+  MAX_SCREENSHOT_SIZE_MB: '5',
+  ASSETS: {} as Fetcher,
+};
+
+function createStore(overrides: Partial<KVNamespace> = {}): KVNamespace {
+  return {
+    delete: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null),
+    getWithMetadata: vi.fn(),
+    list: vi.fn().mockResolvedValue({ keys: [], list_complete: true, cacheStatus: null }),
+    put: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as KVNamespace;
+}
+
+async function sign(body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(baseEnv.GITHUB_WEBHOOK_SECRET!),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const digest = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body))
+  );
+  return `sha256=${Array.from(digest, byte => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+describe('installation cleanup boundaries', () => {
+  it('validates installation IDs before constructing or deleting keys', async () => {
+    const store = createStore();
+    expect(installationRecordKey(42)).toBe('installation:42');
+    expect(() => installationRecordKey(0)).toThrow('Invalid installation ID');
+    expect(() => installationRecordKey(1.5)).toThrow('Invalid installation ID');
+    await expect(deleteInstallationRecord(store, -1)).rejects.toThrow('Invalid installation ID');
+    expect(store.delete).not.toHaveBeenCalled();
+  });
+
+  it('confirms a candidate is inactive before destructive cleanup', async () => {
+    const activeResponse = new Response('{}', { status: 200 });
+    const missingResponse = new Response('{}', { status: 404 });
+    const failureResponse = new Response('{}', { status: 500 });
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(activeResponse)
+      .mockResolvedValueOnce(missingResponse);
+    const options = {
+      fetchImpl,
+      createJwt: vi.fn().mockResolvedValue('app-jwt'),
+    };
+
+    await expect(confirmGitHubInstallationIsInactive(baseEnv, 42, options)).resolves.toBe(false);
+    await expect(confirmGitHubInstallationIsInactive(baseEnv, 43, options)).resolves.toBe(true);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/app/installations/43',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer app-jwt' }),
+      })
+    );
+
+    await expect(
+      confirmGitHubInstallationIsInactive(baseEnv, 44, {
+        fetchImpl: vi.fn().mockResolvedValue(failureResponse),
+        createJwt: vi.fn().mockResolvedValue('app-jwt'),
+      })
+    ).rejects.toThrow('Failed to confirm GitHub App installation: 500');
+    expect(activeResponse.bodyUsed).toBe(true);
+    expect(missingResponse.bodyUsed).toBe(true);
+    expect(failureResponse.bodyUsed).toBe(true);
+  });
+
+  it('checkpoints after one bounded KV page instead of claiming a partial sweep succeeded', async () => {
+    let concurrentConfirmations = 0;
+    let peakConfirmations = 0;
+    const confirmInstallationIsInactive = vi.fn(async () => {
+      concurrentConfirmations += 1;
+      peakConfirmations = Math.max(peakConfirmations, concurrentConfirmations);
+      await Promise.resolve();
+      concurrentConfirmations -= 1;
+      return true;
+    });
+    const keys = Array.from({ length: INSTALLATION_SWEEP_PAGE_SIZE }, (_, index) => ({
+      name: `installation:${index + 1}`,
+    }));
+    const store = createStore({
+      list: vi.fn().mockResolvedValue({
+        keys,
+        list_complete: false,
+        cursor: 'page-2',
+        cacheStatus: null,
+      }),
+    });
+
+    const result = await sweepInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {
+        listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()),
+        confirmInstallationIsInactive,
+      }
+    );
+
+    expect(result).toBeNull();
+    expect(store.delete).toHaveBeenCalledTimes(INSTALLATION_SWEEP_PAGE_SIZE);
+    expect(confirmInstallationIsInactive).toHaveBeenCalledTimes(INSTALLATION_SWEEP_PAGE_SIZE);
+    expect(peakConfirmations).toBe(MAX_CONCURRENT_CLEANUP_OPERATIONS);
+    expect(MAX_GITHUB_INSTALLATION_PAGES + INSTALLATION_SWEEP_PAGE_SIZE).toBeLessThanOrEqual(50);
+    expect(store.put).toHaveBeenCalledExactlyOnceWith(
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      expect.stringContaining('"cursor":"page-2"')
+    );
+    expect(store.put).not.toHaveBeenCalledWith(INSTALLATION_CLEANUP_AUDIT_KEY, expect.anything());
+  });
+
+  it('preserves an active record omitted by a shifting GitHub pagination boundary', async () => {
+    const store = createStore({
+      list: vi.fn().mockResolvedValue({
+        keys: [{ name: 'installation:101' }],
+        list_complete: true,
+        cacheStatus: null,
+      }),
+    });
+    const confirmInstallationIsInactive = vi.fn().mockResolvedValue(false);
+
+    const result = await sweepInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {
+        listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()),
+        confirmInstallationIsInactive,
+      }
+    );
+
+    expect(confirmInstallationIsInactive).toHaveBeenCalledExactlyOnceWith(expect.anything(), 101);
+    expect(store.delete).toHaveBeenCalledExactlyOnceWith(INSTALLATION_CLEANUP_CHECKPOINT_KEY);
+    expect(result?.deletedCount).toBe(0);
+  });
+
+  it('does not delete or record success when candidate confirmation fails', async () => {
+    const store = createStore({
+      list: vi.fn().mockResolvedValue({
+        keys: [{ name: 'installation:101' }],
+        list_complete: true,
+        cacheStatus: null,
+      }),
+    });
+
+    await expect(
+      sweepInstallationRecords(
+        { ...baseEnv, INSTALLATION_ANALYTICS: store },
+        {
+          listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()),
+          confirmInstallationIsInactive: vi.fn().mockRejectedValue(new Error('GitHub unavailable')),
+        }
+      )
+    ).rejects.toThrow('GitHub unavailable');
+    expect(store.delete).not.toHaveBeenCalled();
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on a malformed cleanup checkpoint', async () => {
+    const impossibleCheckpoint = {
+      schemaVersion: 1,
+      cursor: 'page-2',
+      startedAt: '2026-08-28T12:00:00.000Z',
+      scannedCount: 0,
+      deletedCount: 50,
+    };
+    const store = createStore({
+      get: vi.fn().mockResolvedValue(JSON.stringify(impossibleCheckpoint)),
+    });
+
+    await expect(
+      sweepInstallationRecords(
+        { ...baseEnv, INSTALLATION_ANALYTICS: store },
+        { listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()) }
+      )
+    ).rejects.toThrow('Malformed installation cleanup checkpoint');
+    expect(store.list).not.toHaveBeenCalled();
+    expect(store.delete).not.toHaveBeenCalled();
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('mounts the authenticated webhook at the production API path', async () => {
+    const store = createStore();
+    const body = JSON.stringify({ action: 'deleted', installation: { id: 42 } });
+    const response = await worker.fetch(
+      new Request('https://bugdrop.dev/api/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {} as ExecutionContext
+    );
+
+    expect(response.status).toBe(200);
+    expect(store.delete).toHaveBeenCalledExactlyOnceWith('installation:42');
+  });
+
+  it('binds isolated storage, the first-party route, and daily cleanup triggers', () => {
+    const config = readFileSync('wrangler.toml', 'utf8');
+
+    expect(config.match(/binding = "INSTALLATION_ANALYTICS"/g)).toHaveLength(3);
+    expect(config.match(/crons = \["17 3 \* \* \*"\]/g)).toHaveLength(2);
+    expect(config.match(/bugdrop\.dev\/api\/github\/webhook\*/g)).toHaveLength(2);
+    expect(config.indexOf('routes = [')).toBeLessThan(config.indexOf('[triggers]'));
+    expect(config).toContain('id = "a567f723a2eb4cfab807b0c1d678dc76"');
+    expect(config).toContain('id = "c58b33f6a0dc416b8661661ce0d23f7f"');
+  });
+});

--- a/test/installationRetention.test.ts
+++ b/test/installationRetention.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/types';
+import {
+  INSTALLATION_CLEANUP_AUDIT_KEY,
+  INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+  listActiveGitHubInstallationIds,
+  sweepInstallationRecords,
+  verifyGitHubWebhookSignature,
+} from '../src/lib/installation-retention';
+import githubWebhook from '../src/routes/github-webhook';
+
+const baseEnv: Env = {
+  GITHUB_APP_ID: '123',
+  GITHUB_PRIVATE_KEY: 'test-private-key',
+  GITHUB_WEBHOOK_SECRET: "It's a Secret to Everybody",
+  ENVIRONMENT: 'test',
+  ALLOWED_ORIGINS: '*',
+  GITHUB_APP_NAME: 'test-bugdrop-app',
+  MAX_SCREENSHOT_SIZE_MB: '5',
+  ASSETS: {} as Fetcher,
+};
+
+function createStore(overrides: Partial<KVNamespace> = {}): KVNamespace {
+  return {
+    delete: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn().mockResolvedValue(null),
+    getWithMetadata: vi.fn(),
+    list: vi.fn().mockResolvedValue({ keys: [], list_complete: true, cacheStatus: null }),
+    put: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as KVNamespace;
+}
+
+async function sign(body: string, secret = baseEnv.GITHUB_WEBHOOK_SECRET!): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const digest = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body))
+  );
+  return `sha256=${Array.from(digest, byte => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+describe('installation retention safeguards', () => {
+  it('matches GitHub’s published SHA-256 webhook validation vector', async () => {
+    await expect(
+      verifyGitHubWebhookSignature(
+        "It's a Secret to Everybody",
+        'sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17',
+        'Hello, World!'
+      )
+    ).resolves.toBe(true);
+    await expect(
+      verifyGitHubWebhookSignature(
+        "It's a Secret to Everybody",
+        'sha256=057107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17',
+        'Hello, World!'
+      )
+    ).resolves.toBe(false);
+  });
+
+  it('deletes only the uninstalled app record after authenticating the webhook', async () => {
+    const store = createStore();
+    const body = JSON.stringify({ action: 'deleted', installation: { id: 987654 } });
+    const response = await githubWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store }
+    );
+
+    expect(response.status).toBe(200);
+    expect(store.delete).toHaveBeenCalledExactlyOnceWith('installation:987654');
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsigned deliveries and fails visibly when deletion storage is unavailable', async () => {
+    const body = JSON.stringify({ action: 'deleted', installation: { id: 42 } });
+    const unsigned = await githubWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-github-event': 'installation' },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: createStore() }
+    );
+    const missingStore = await githubWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      baseEnv
+    );
+
+    expect(unsigned.status).toBe(401);
+    expect(missingStore.status).toBe(503);
+  });
+
+  it('acknowledges unrelated or non-deletion events without writing installation records', async () => {
+    const store = createStore();
+    const body = JSON.stringify({ action: 'created', installation: { id: 42 } });
+    const response = await githubWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store }
+    );
+
+    expect(response.status).toBe(202);
+    expect(store.delete).not.toHaveBeenCalled();
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('paginates GitHub’s active-installation list', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({ id: index + 1 }));
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json(firstPage))
+      .mockResolvedValueOnce(Response.json([{ id: 101 }]));
+
+    const ids = await listActiveGitHubInstallationIds(baseEnv, {
+      fetchImpl,
+      createJwt: vi.fn().mockResolvedValue('app-jwt'),
+    });
+
+    expect(ids.size).toBe(101);
+    expect(ids.has(1)).toBe(true);
+    expect(ids.has(101)).toBe(true);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/app/installations?per_page=100&page=2',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer app-jwt' }),
+      })
+    );
+  });
+
+  it('deletes stale records across KV pages and records anonymous cleanup evidence', async () => {
+    const checkpoint = {
+      schemaVersion: 1,
+      cursor: 'next-page',
+      startedAt: '2026-08-28T12:00:00.000Z',
+      scannedCount: 2,
+      deletedCount: 1,
+    };
+    const store = createStore({
+      get: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(JSON.stringify(checkpoint)),
+      list: vi
+        .fn()
+        .mockResolvedValueOnce({
+          keys: [{ name: 'installation:1' }, { name: 'installation:2' }],
+          list_complete: false,
+          cursor: 'next-page',
+          cacheStatus: null,
+        })
+        .mockResolvedValueOnce({
+          keys: [{ name: 'installation:3' }],
+          list_complete: true,
+          cacheStatus: null,
+        }),
+    });
+
+    const listActiveInstallationIds = vi.fn().mockResolvedValue(new Set([1, 3]));
+    const firstResult = await sweepInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {
+        now: new Date('2026-08-28T12:00:00.000Z'),
+        listActiveInstallationIds,
+        confirmInstallationIsInactive: vi.fn().mockResolvedValue(true),
+      }
+    );
+    const result = await sweepInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {
+        now: new Date('2026-08-28T12:00:00.000Z'),
+        listActiveInstallationIds,
+        confirmInstallationIsInactive: vi.fn().mockResolvedValue(true),
+      }
+    );
+
+    expect(firstResult).toBeNull();
+    expect(result).toEqual({
+      schemaVersion: 1,
+      completedAt: '2026-08-28T12:00:00.000Z',
+      scannedCount: 3,
+      activeCount: 2,
+      deletedCount: 1,
+    });
+    expect(store.list).toHaveBeenNthCalledWith(1, {
+      prefix: 'installation:',
+      limit: 25,
+    });
+    expect(store.list).toHaveBeenNthCalledWith(2, {
+      prefix: 'installation:',
+      limit: 25,
+      cursor: 'next-page',
+    });
+    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation:2');
+    expect(store.delete).toHaveBeenNthCalledWith(2, INSTALLATION_CLEANUP_CHECKPOINT_KEY);
+    expect(store.delete).toHaveBeenCalledTimes(2);
+    expect(store.put).toHaveBeenNthCalledWith(
+      1,
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      JSON.stringify(checkpoint)
+    );
+    expect(store.put).toHaveBeenNthCalledWith(
+      2,
+      INSTALLATION_CLEANUP_AUDIT_KEY,
+      JSON.stringify(result)
+    );
+    expect(store.put).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(result)).not.toContain('installation:2');
+  });
+
+  it('never records a successful sweep when GitHub or deletion fails', async () => {
+    const githubFailureStore = createStore({
+      list: vi.fn().mockResolvedValue({
+        keys: [{ name: 'installation:2' }],
+        list_complete: true,
+        cacheStatus: null,
+      }),
+    });
+    await expect(
+      sweepInstallationRecords(
+        { ...baseEnv, INSTALLATION_ANALYTICS: githubFailureStore },
+        { listActiveInstallationIds: vi.fn().mockRejectedValue(new Error('GitHub unavailable')) }
+      )
+    ).rejects.toThrow('GitHub unavailable');
+    expect(githubFailureStore.delete).not.toHaveBeenCalled();
+    expect(githubFailureStore.put).not.toHaveBeenCalled();
+
+    const deletionFailureStore = createStore({
+      delete: vi.fn().mockRejectedValue(new Error('KV deletion failed')),
+      list: vi.fn().mockResolvedValue({
+        keys: [{ name: 'installation:2' }],
+        list_complete: true,
+        cacheStatus: null,
+      }),
+    });
+    await expect(
+      sweepInstallationRecords(
+        { ...baseEnv, INSTALLATION_ANALYTICS: deletionFailureStore },
+        {
+          listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()),
+          confirmInstallationIsInactive: vi.fn().mockResolvedValue(true),
+        }
+      )
+    ).rejects.toThrow('KV deletion failed');
+    expect(deletionFailureStore.put).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed record IDs rather than silently skipping cleanup', async () => {
+    const store = createStore({
+      list: vi.fn().mockResolvedValue({
+        keys: [{ name: 'installation:not-a-number' }],
+        list_complete: true,
+        cacheStatus: null,
+      }),
+    });
+
+    await expect(
+      sweepInstallationRecords(
+        { ...baseEnv, INSTALLATION_ANALYTICS: store },
+        {
+          listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()),
+          confirmInstallationIsInactive: vi.fn().mockResolvedValue(true),
+        }
+      )
+    ).rejects.toThrow('Malformed installation record key');
+    expect(store.put).not.toHaveBeenCalled();
+  });
+});

--- a/test/installationRetention.test.ts
+++ b/test/installationRetention.test.ts
@@ -159,6 +159,7 @@ describe('installation retention safeguards', () => {
   it('deletes stale records across KV pages and records anonymous cleanup evidence', async () => {
     const checkpoint = {
       schemaVersion: 1,
+      phase: 'scanning',
       cursor: 'next-page',
       startedAt: '2026-08-28T12:00:00.000Z',
       scannedCount: 2,
@@ -222,52 +223,30 @@ describe('installation retention safeguards', () => {
     expect(store.put).toHaveBeenNthCalledWith(
       1,
       INSTALLATION_CLEANUP_CHECKPOINT_KEY,
-      JSON.stringify(checkpoint)
+      JSON.stringify({
+        schemaVersion: 1,
+        phase: 'deleting',
+        installationIds: [2],
+        next: checkpoint,
+      })
     );
     expect(store.put).toHaveBeenNthCalledWith(
       2,
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      JSON.stringify(checkpoint)
+    );
+    expect(store.put).toHaveBeenNthCalledWith(
+      3,
+      INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+      JSON.stringify({ schemaVersion: 1, phase: 'finalizing', audit: result })
+    );
+    expect(store.put).toHaveBeenNthCalledWith(
+      4,
       INSTALLATION_CLEANUP_AUDIT_KEY,
       JSON.stringify(result)
     );
-    expect(store.put).toHaveBeenCalledTimes(2);
+    expect(store.put).toHaveBeenCalledTimes(4);
     expect(JSON.stringify(result)).not.toContain('installation:2');
-  });
-
-  it('never records a successful sweep when GitHub or deletion fails', async () => {
-    const githubFailureStore = createStore({
-      list: vi.fn().mockResolvedValue({
-        keys: [{ name: 'installation:2' }],
-        list_complete: true,
-        cacheStatus: null,
-      }),
-    });
-    await expect(
-      sweepInstallationRecords(
-        { ...baseEnv, INSTALLATION_ANALYTICS: githubFailureStore },
-        { listActiveInstallationIds: vi.fn().mockRejectedValue(new Error('GitHub unavailable')) }
-      )
-    ).rejects.toThrow('GitHub unavailable');
-    expect(githubFailureStore.delete).not.toHaveBeenCalled();
-    expect(githubFailureStore.put).not.toHaveBeenCalled();
-
-    const deletionFailureStore = createStore({
-      delete: vi.fn().mockRejectedValue(new Error('KV deletion failed')),
-      list: vi.fn().mockResolvedValue({
-        keys: [{ name: 'installation:2' }],
-        list_complete: true,
-        cacheStatus: null,
-      }),
-    });
-    await expect(
-      sweepInstallationRecords(
-        { ...baseEnv, INSTALLATION_ANALYTICS: deletionFailureStore },
-        {
-          listActiveInstallationIds: vi.fn().mockResolvedValue(new Set<number>()),
-          confirmInstallationIsInactive: vi.fn().mockResolvedValue(true),
-        }
-      )
-    ).rejects.toThrow('KV deletion failed');
-    expect(deletionFailureStore.put).not.toHaveBeenCalled();
   });
 
   it('rejects malformed record IDs rather than silently skipping cleanup', async () => {

--- a/test/installationRetentionConfig.test.ts
+++ b/test/installationRetentionConfig.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('installation retention configuration', () => {
+  it('binds isolated storage, the first-party route, and daily cleanup triggers', () => {
+    const config = readFileSync('wrangler.toml', 'utf8');
+
+    expect(config.match(/binding = "INSTALLATION_ANALYTICS"/g)).toHaveLength(3);
+    expect(config.match(/crons = \["17 3 \* \* \*"\]/g)).toHaveLength(2);
+    expect(config.match(/bugdrop\.dev\/api\/github\/webhook\*/g)).toHaveLength(2);
+    expect(config.indexOf('routes = [')).toBeLessThan(config.indexOf('[triggers]'));
+    expect(config).toContain('id = "a567f723a2eb4cfab807b0c1d678dc76"');
+    expect(config).toContain('id = "c58b33f6a0dc416b8661661ce0d23f7f"');
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,11 @@ routes = [
   { pattern = "bugdrop.dev/board*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/board-dogfood*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/api/bugdrop-board-token*", zone_name = "bugdrop.dev" },
+  { pattern = "bugdrop.dev/api/github/webhook*", zone_name = "bugdrop.dev" },
 ]
+
+[triggers]
+crons = ["17 3 * * *"]
 
 # Static assets directory (for widget.js)
 [assets]
@@ -29,9 +33,14 @@ binding = "RATE_LIMIT"
 id = "e6454ed79f514ed3a9e24eea99dd6cd3"
 preview_id = "ff8f3809037d4403befd09369a9f7e36"
 
+[[kv_namespaces]]
+binding = "INSTALLATION_ANALYTICS"
+id = "a567f723a2eb4cfab807b0c1d678dc76"
+
 # Secrets (set with: wrangler secret put GITHUB_APP_ID)
 # GITHUB_APP_ID
 # GITHUB_PRIVATE_KEY
+# GITHUB_WEBHOOK_SECRET
 # AUTH_TOKEN_SECRET  # Optional: set to require signed host-app auth tokens for /feedback
 # VARIANT_LABELS  # Optional: JSON object keyed by repo, then structured variant ID
 # BUGDROP_BOARD_TOKEN_SECRET  # Optional: enables /board embedded demo token signing
@@ -52,6 +61,10 @@ MAX_SCREENSHOT_SIZE_MB = "5"
 binding = "RATE_LIMIT"
 id = "cdb88fa95d6348d6ab84037751853d5d"
 
+[[env.preview.kv_namespaces]]
+binding = "INSTALLATION_ANALYTICS"
+id = "c58b33f6a0dc416b8661661ce0d23f7f"
+
 # Controller-owned production target. The release workflow must still pass
 # BUILD_SHA explicitly and remains frozen until the later operator cutover.
 [env.production]
@@ -61,7 +74,11 @@ routes = [
   { pattern = "bugdrop.dev/board*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/board-dogfood*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/api/bugdrop-board-token*", zone_name = "bugdrop.dev" },
+  { pattern = "bugdrop.dev/api/github/webhook*", zone_name = "bugdrop.dev" },
 ]
+
+[env.production.triggers]
+crons = ["17 3 * * *"]
 
 [env.production.assets]
 directory = "public"
@@ -78,3 +95,7 @@ BUGDROP_BOARD_APP_ID = "app_mean_weasel_bugdrop_dogfood"
 [[env.production.kv_namespaces]]
 binding = "RATE_LIMIT"
 id = "e6454ed79f514ed3a9e24eea99dd6cd3"
+
+[[env.production.kv_namespaces]]
+binding = "INSTALLATION_ANALYTICS"
+id = "a567f723a2eb4cfab807b0c1d678dc76"


### PR DESCRIPTION
## Summary

- authenticate GitHub installation webhooks and immediately delete an uninstalled app record
- add a bounded daily reconciliation backstop that confirms inactivity before deletion
- make cleanup retries durable across deletion, checkpoint, and audit-publication failures
- provision isolated preview and production KV bindings without enabling installation analytics collection

## Privacy boundary

This change does not collect installation names, account names, usage activity, feedback content, screenshots, attachments, or console logs. Installation-created events are acknowledged without writes. The only persisted operational evidence is anonymous cleanup counts.

## Verification

- npm run validate (99 files, 1,525 tests)
- preview and production Wrangler dry runs
- signed webhook route test at https://bugdrop.dev/api/github/webhook
- destructive pagination-race and cleanup-retry regression tests
- Cloudflare limits: at most 45 GitHub subrequests and 6 concurrent cleanup operations
- production and preview KV namespaces verified empty
- PR review toolkit completed; all accepted findings fixed and re-reviewed

## Activation

After approval and merge, configure the shared webhook secret and GitHub App webhook URL, then verify a signed delivery before any future analytics collection is considered.
