### PR TITLE
feat: collect minimal installation identities

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated:** August 27, 2026
+**Last updated:** August 28, 2026
 
 BugDrop is an open-source feedback widget that creates GitHub Issues. This policy covers
 the hosted BugDrop widget and service, as well as the BugDrop website at
@@ -31,23 +31,21 @@ BugDrop applies best-effort secret redaction, but console output can still conta
 or confidential information. Reporters should consider that risk before choosing to
 include it.
 
-## Installation and Usage Information
+## Installation Information
 
-BugDrop does not currently retain identifiable installation analytics. After automated
-deletion for uninstalled apps and a verifiable cleanup backstop are in place, the hosted
-service may retain a minimal installation record containing:
+The hosted service retains a minimal record for installations created after this collection
+was enabled. The record contains:
 
 - GitHub App installation ID
 - Public GitHub account name, account type, and profile link
-- Installation, suspension, removal, and last-active dates
-- Total number of feedback issues successfully created through that installation
+- Installation date
 
 BugDrop does not retain repository names, issue content, screenshots, page URLs,
 reporter identities, or IP addresses for product analytics.
 
-This information is used to operate BugDrop, understand aggregate adoption and usage,
-maintain accurate public totals, and invite app owners to participate voluntarily in
-product research or social proof.
+This information is used to operate BugDrop, understand aggregate adoption, and invite app
+owners to participate voluntarily in product research or social proof. BugDrop does not
+currently retain per-installation feedback counts or last-active dates.
 
 ## Public Statistics
 
@@ -141,9 +139,9 @@ request paths, for service delivery, security, and operational logs.
 - Feedback content is discarded by the hosted service after the GitHub request completes.
 - IP-based rate-limit records expire 15 minutes after their most recent update.
 - Repository-based rate-limit records expire one hour after their most recent update.
-- Identifiable installation analytics are not currently retained. If enabled after
-  automated deletion for uninstalled apps and a verifiable cleanup backstop are in place,
-  installation records may be retained while an installation is active.
+- Installation records are retained while an installation is active and deleted when the
+  app is uninstalled. A scheduled cleanup independently removes records for installations
+  GitHub no longer reports as active.
 - Anonymous aggregate totals may be retained indefinitely.
 - Testimonial and contact information provided with explicit permission is retained until
   that permission is withdrawn or the information is no longer needed.

--- a/docs/website/faq.mdx
+++ b/docs/website/faq.mdx
@@ -179,8 +179,8 @@ The widget does not track feedback reporters. It does not set analytics cookies,
 browser storage to track reporters, send reporter analytics, or fingerprint users.
 Feedback form contents go to the hosted service only to create the requested GitHub Issue
 and associated files. BugDrop does not retain that content in a separate feedback
-database. The service does keep short-lived rate-limit counters and may retain limited
-installation and aggregate usage information.
+database. The service does keep short-lived rate-limit counters and limited installation
+information.
 
 Separately, the bugdrop.dev website uses limited website analytics. See the
 [Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md) for details.
@@ -193,8 +193,8 @@ Feedback data is stored in your GitHub repository:
 - **Screenshots** are committed to the `bugdrop-screenshots` branch in a `.bugdrop/` directory
 
 The API discards feedback content after creating the GitHub Issue and associated files.
-The hosted service separately keeps short-lived rate-limit counters and may retain the
-limited installation and aggregate usage information described in the
+The hosted service separately keeps short-lived rate-limit counters and the limited
+installation information described in the
 [Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md).
 
 ### Can I self-host BugDrop?

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -28,8 +28,8 @@ You can review and revoke the app's access at any time from your GitHub settings
 
 BugDrop follows a "GitHub-native" feedback-storage model. Feedback content and uploaded
 files are stored in your GitHub repository, not in a separate BugDrop feedback database.
-The hosted service temporarily stores rate-limit counters and may retain limited
-installation and aggregate usage information as described in the
+The hosted service temporarily stores rate-limit counters and limited installation
+information as described in the
 [Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md).
 
 ### Issues

--- a/src/lib/installation-analytics.ts
+++ b/src/lib/installation-analytics.ts
@@ -1,0 +1,122 @@
+import { installationRecordKey } from './installation-retention';
+
+type InstallationAccountType = 'User' | 'Organization';
+
+interface InstallationIdentityRecord {
+  schemaVersion: 1;
+  installationId: number;
+  account: {
+    login: string;
+    type: InstallationAccountType;
+    profileUrl: string;
+  };
+  installedAt: string;
+}
+
+export interface NewInstallationRecord {
+  installationId: number;
+  account: InstallationIdentityRecord['account'];
+  installedAt: string;
+}
+
+export async function createInstallationRecord(
+  store: KVNamespace,
+  installation: NewInstallationRecord
+): Promise<void> {
+  const key = installationRecordKey(installation.installationId);
+  const existing = await store.get(key);
+  if (existing !== null) {
+    const record = parseInstallationIdentityRecord(existing, installation.installationId);
+    assertInstallationIdentityRecord(record, installation.installationId);
+    return;
+  }
+
+  const record: InstallationIdentityRecord = {
+    schemaVersion: 1,
+    installationId: installation.installationId,
+    account: installation.account,
+    installedAt: installation.installedAt,
+  };
+  assertInstallationIdentityRecord(record, installation.installationId);
+  await store.put(key, JSON.stringify(record));
+}
+
+function parseInstallationIdentityRecord(value: string, installationId: number): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    throw new Error(`Invalid installation identity record for ${installationId}`);
+  }
+}
+
+function assertInstallationIdentityRecord(
+  value: unknown,
+  expectedInstallationId: number
+): asserts value is InstallationIdentityRecord {
+  if (!isPlainObject(value) || !hasExactKeys(value, RECORD_KEYS)) {
+    throw new Error('Invalid installation identity record');
+  }
+  if (
+    value.schemaVersion !== 1 ||
+    value.installationId !== expectedInstallationId ||
+    !isPlainObject(value.account) ||
+    !hasExactKeys(value.account, ACCOUNT_KEYS) ||
+    typeof value.account.login !== 'string' ||
+    !isGitHubAccountLogin(value.account.login) ||
+    !isInstallationAccountType(value.account.type) ||
+    typeof value.account.profileUrl !== 'string' ||
+    !isCanonicalGitHubProfileUrl(value.account.profileUrl, value.account.login) ||
+    !isIsoDate(value.installedAt)
+  ) {
+    throw new Error('Invalid installation identity record');
+  }
+}
+
+export function isInstallationAccountType(value: unknown): value is InstallationAccountType {
+  return value === 'User' || value === 'Organization';
+}
+
+export function isGitHubAccountLogin(value: string): boolean {
+  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,98}[A-Za-z0-9])?$/.test(value);
+}
+
+export function isCanonicalGitHubProfileUrl(value: string, login: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === 'https:' &&
+      url.hostname === 'github.com' &&
+      url.port === '' &&
+      url.username === '' &&
+      url.password === '' &&
+      url.search === '' &&
+      url.hash === '' &&
+      (url.pathname === `/${login}` || url.pathname === `/${login}/`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+const RECORD_KEYS = ['schemaVersion', 'installationId', 'account', 'installedAt'] as const;
+const ACCOUNT_KEYS = ['login', 'type', 'profileUrl'] as const;
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  return (
+    actual.length === expected.length &&
+    [...expected].sort().every((key, index) => actual[index] === key)
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isIsoDate(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    !Number.isNaN(Date.parse(value)) &&
+    new Date(value).toISOString() === value
+  );
+}

--- a/src/routes/github-webhook.ts
+++ b/src/routes/github-webhook.ts
@@ -1,62 +1,99 @@
 import { Hono } from 'hono';
 import type { Env } from '../types';
 import {
+  confirmGitHubInstallationIsInactive,
   deleteInstallationRecord,
   verifyGitHubWebhookSignature,
 } from '../lib/installation-retention';
+import {
+  createInstallationRecord,
+  isCanonicalGitHubProfileUrl,
+  isGitHubAccountLogin,
+  isInstallationAccountType,
+  type NewInstallationRecord,
+} from '../lib/installation-analytics';
 
-const githubWebhook = new Hono<{ Bindings: Env }>();
+interface GitHubWebhookDependencies {
+  confirmInstallationIsInactive?: (env: Env, installationId: number) => Promise<boolean>;
+}
 
-githubWebhook.post('/github/webhook', async c => {
-  const secret = c.env.GITHUB_WEBHOOK_SECRET;
-  if (!secret) {
-    return c.json({ error: 'GitHub webhook is not configured' }, 503);
-  }
+export function createGitHubWebhook(dependencies: GitHubWebhookDependencies = {}) {
+  const githubWebhook = new Hono<{ Bindings: Env }>();
+  const confirmInstallationIsInactive =
+    dependencies.confirmInstallationIsInactive ?? confirmGitHubInstallationIsInactive;
 
-  const body = await c.req.text();
-  const signatureIsValid = await verifyGitHubWebhookSignature(
-    secret,
-    c.req.header('x-hub-signature-256'),
-    body
-  );
-  if (!signatureIsValid) {
-    return c.json({ error: 'Invalid webhook signature' }, 401);
-  }
+  githubWebhook.post('/github/webhook', async c => {
+    const secret = c.env.GITHUB_WEBHOOK_SECRET;
+    if (!secret) {
+      return c.json({ error: 'GitHub webhook is not configured' }, 503);
+    }
 
-  const event = c.req.header('x-github-event');
-  if (!event) {
-    return c.json({ error: 'Missing GitHub event type' }, 400);
-  }
-  if (event !== 'installation') {
-    return c.json({ accepted: true }, 202);
-  }
+    const body = await c.req.text();
+    const signatureIsValid = await verifyGitHubWebhookSignature(
+      secret,
+      c.req.header('x-hub-signature-256'),
+      body
+    );
+    if (!signatureIsValid) {
+      return c.json({ error: 'Invalid webhook signature' }, 401);
+    }
 
-  const payload = parseInstallationPayload(body);
-  if (!payload) {
-    return c.json({ error: 'Invalid installation webhook payload' }, 400);
-  }
-  if (payload.action !== 'deleted') {
-    return c.json({ accepted: true }, 202);
-  }
+    const event = c.req.header('x-github-event');
+    if (!event) {
+      return c.json({ error: 'Missing GitHub event type' }, 400);
+    }
+    if (event !== 'installation') {
+      return c.json({ accepted: true }, 202);
+    }
 
-  const store = c.env.INSTALLATION_ANALYTICS;
-  if (!store) {
-    return c.json({ error: 'Installation deletion storage is unavailable' }, 503);
-  }
+    const payload = parseInstallationPayload(body);
+    if (!payload) {
+      return c.json({ error: 'Invalid installation webhook payload' }, 400);
+    }
+    if (payload.kind === 'ignored') {
+      return c.json({ accepted: true }, 202);
+    }
 
-  await deleteInstallationRecord(store, payload.installation.id);
-  return c.json({ deleted: true }, 200);
-});
+    const store = c.env.INSTALLATION_ANALYTICS;
+    if (!store) {
+      return c.json({ error: 'Installation identity storage is unavailable' }, 503);
+    }
 
-function parseInstallationPayload(
-  body: string
-): { action: string; installation: { id: number } } | null {
+    if (payload.kind === 'created') {
+      if (await confirmInstallationIsInactive(c.env, payload.installation.installationId)) {
+        return c.json({ accepted: true }, 202);
+      }
+      await createInstallationRecord(store, payload.installation);
+      if (await confirmInstallationIsInactive(c.env, payload.installation.installationId)) {
+        await deleteInstallationRecord(store, payload.installation.installationId);
+        return c.json({ accepted: true }, 202);
+      }
+      return c.json({ created: true }, 201);
+    }
+
+    await deleteInstallationRecord(store, payload.installation.installationId);
+    return c.json({ deleted: true }, 200);
+  });
+
+  return githubWebhook;
+}
+
+type InstallationPayload =
+  | { kind: 'created'; installation: NewInstallationRecord }
+  | { kind: 'deleted'; installation: { installationId: number } }
+  | { kind: 'ignored'; installation: { installationId: number } };
+
+function parseInstallationPayload(body: string): InstallationPayload | null {
   try {
     const payload = JSON.parse(body) as unknown;
     if (!payload || typeof payload !== 'object') return null;
     const candidate = payload as {
       action?: unknown;
-      installation?: { id?: unknown };
+      installation?: {
+        id?: unknown;
+        account?: { login?: unknown; type?: unknown; html_url?: unknown };
+        created_at?: unknown;
+      };
     };
     const id = candidate.installation?.id;
     if (
@@ -67,10 +104,47 @@ function parseInstallationPayload(
     ) {
       return null;
     }
-    return { action: candidate.action, installation: { id } };
+    if (candidate.action !== 'created') {
+      return {
+        kind: candidate.action === 'deleted' ? 'deleted' : 'ignored',
+        installation: { installationId: id },
+      };
+    }
+
+    const account = candidate.installation?.account;
+    const installedAt = normalizeGitHubDate(candidate.installation?.created_at);
+    if (
+      !account ||
+      typeof account.login !== 'string' ||
+      !isGitHubAccountLogin(account.login) ||
+      !isInstallationAccountType(account.type) ||
+      typeof account.html_url !== 'string' ||
+      !isCanonicalGitHubProfileUrl(account.html_url, account.login) ||
+      !installedAt
+    ) {
+      return null;
+    }
+
+    return {
+      kind: 'created',
+      installation: {
+        installationId: id,
+        account: {
+          login: account.login,
+          type: account.type,
+          profileUrl: account.html_url,
+        },
+        installedAt,
+      },
+    };
   } catch {
     return null;
   }
 }
 
-export default githubWebhook;
+function normalizeGitHubDate(value: unknown): string | null {
+  if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) return null;
+  return new Date(value).toISOString();
+}
+
+export default createGitHubWebhook();

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export interface Env {
   // Bindings
   ASSETS: Fetcher;
   RATE_LIMIT?: KVNamespace; // Optional: for rate limiting (create with wrangler kv:namespace create RATE_LIMIT)
-  INSTALLATION_ANALYTICS?: KVNamespace; // Deletion-ready installation records; collection remains disabled
+  INSTALLATION_ANALYTICS?: KVNamespace; // Minimal installation identity records
 }
 
 export type FeedbackCategory = 'bug' | 'feature' | 'question';

--- a/test/installationRetention.test.ts
+++ b/test/installationRetention.test.ts
@@ -7,7 +7,11 @@ import {
   sweepInstallationRecords,
   verifyGitHubWebhookSignature,
 } from '../src/lib/installation-retention';
-import githubWebhook from '../src/routes/github-webhook';
+import { createGitHubWebhook } from '../src/routes/github-webhook';
+
+const githubWebhook = createGitHubWebhook({
+  confirmInstallationIsInactive: vi.fn().mockResolvedValue(false),
+});
 
 const baseEnv: Env = {
   GITHUB_APP_ID: '123',
@@ -113,7 +117,7 @@ describe('installation retention safeguards', () => {
 
   it('acknowledges unrelated or non-deletion events without writing installation records', async () => {
     const store = createStore();
-    const body = JSON.stringify({ action: 'created', installation: { id: 42 } });
+    const body = JSON.stringify({ action: 'suspended', installation: { id: 42 } });
     const response = await githubWebhook.fetch(
       new Request('https://bugdrop.example/github/webhook', {
         method: 'POST',
@@ -130,6 +134,201 @@ describe('installation retention safeguards', () => {
     expect(response.status).toBe(202);
     expect(store.delete).not.toHaveBeenCalled();
     expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('stores only approved public account fields for a newly created installation', async () => {
+    const store = createStore();
+    const body = JSON.stringify({
+      action: 'created',
+      installation: {
+        id: 42,
+        account: {
+          login: 'acme',
+          type: 'Organization',
+          html_url: 'https://github.com/acme',
+          email: 'private@example.com',
+          avatar_url: 'https://avatars.githubusercontent.com/u/1',
+        },
+        created_at: '2026-08-28T12:00:00Z',
+        repository_selection: 'all',
+      },
+      repositories: [{ full_name: 'acme/private-repo' }],
+      sender: { login: 'private-installer' },
+    });
+    const response = await githubWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store }
+    );
+
+    expect(response.status).toBe(201);
+    expect(store.put).toHaveBeenCalledExactlyOnceWith(
+      'installation:42',
+      JSON.stringify({
+        schemaVersion: 1,
+        installationId: 42,
+        account: {
+          login: 'acme',
+          type: 'Organization',
+          profileUrl: 'https://github.com/acme',
+        },
+        installedAt: '2026-08-28T12:00:00.000Z',
+      })
+    );
+    expect(JSON.stringify(vi.mocked(store.put).mock.calls)).not.toContain('private-repo');
+    expect(JSON.stringify(vi.mocked(store.put).mock.calls)).not.toContain('private-installer');
+    expect(JSON.stringify(vi.mocked(store.put).mock.calls)).not.toContain('private@example.com');
+  });
+
+  it('rejects a created-installation payload with a non-canonical profile link', async () => {
+    const store = createStore();
+    const body = JSON.stringify({
+      action: 'created',
+      installation: {
+        id: 42,
+        account: {
+          login: 'acme',
+          type: 'Organization',
+          html_url: 'https://example.com/acme',
+        },
+        created_at: '2026-08-28T12:00:00Z',
+      },
+    });
+    const response = await githubWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store }
+    );
+
+    expect(response.status).toBe(400);
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('does not replace an existing identity record when GitHub redelivers the created event', async () => {
+    const existing = JSON.stringify({
+      schemaVersion: 1,
+      installationId: 42,
+      account: {
+        login: 'acme',
+        type: 'Organization',
+        profileUrl: 'https://github.com/acme',
+      },
+      installedAt: '2026-08-28T12:00:00.000Z',
+    });
+    const store = createStore({ get: vi.fn().mockResolvedValue(existing) });
+    const body = JSON.stringify({
+      action: 'created',
+      installation: {
+        id: 42,
+        account: {
+          login: 'acme',
+          type: 'Organization',
+          html_url: 'https://github.com/acme',
+        },
+        created_at: '2026-08-28T12:00:00Z',
+      },
+    });
+    const response = await githubWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store }
+    );
+
+    expect(response.status).toBe(201);
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('does not recreate an identity record from a delayed created event after uninstall', async () => {
+    const store = createStore();
+    const delayedWebhook = createGitHubWebhook({
+      confirmInstallationIsInactive: vi.fn().mockResolvedValue(true),
+    });
+    const body = JSON.stringify({
+      action: 'created',
+      installation: {
+        id: 42,
+        account: {
+          login: 'acme',
+          type: 'Organization',
+          html_url: 'https://github.com/acme',
+        },
+        created_at: '2026-08-28T12:00:00Z',
+      },
+    });
+    const response = await delayedWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store }
+    );
+
+    expect(response.status).toBe(202);
+    expect(store.put).not.toHaveBeenCalled();
+  });
+
+  it('removes a created record when uninstall happens during creation', async () => {
+    const store = createStore();
+    const confirmInstallationIsInactive = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const racingWebhook = createGitHubWebhook({ confirmInstallationIsInactive });
+    const body = JSON.stringify({
+      action: 'created',
+      installation: {
+        id: 42,
+        account: {
+          login: 'acme',
+          type: 'Organization',
+          html_url: 'https://github.com/acme',
+        },
+        created_at: '2026-08-28T12:00:00Z',
+      },
+    });
+    const response = await racingWebhook.fetch(
+      new Request('https://bugdrop.example/github/webhook', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-github-event': 'installation',
+          'x-hub-signature-256': await sign(body),
+        },
+        body,
+      }),
+      { ...baseEnv, INSTALLATION_ANALYTICS: store }
+    );
+
+    expect(response.status).toBe(202);
+    expect(confirmInstallationIsInactive).toHaveBeenCalledTimes(2);
+    expect(store.put).toHaveBeenCalledOnce();
+    expect(store.delete).toHaveBeenCalledExactlyOnceWith('installation:42');
   });
 
   it('paginates GitHub’s active-installation list', async () => {


### PR DESCRIPTION
## Summary

- Retain only the public GitHub identity and install date for future installations.
- Verify created installations remain active both before and after storage, while preserving deletion and cleanup behavior.
- Update privacy documentation to match the exact collection scope.

## Privacy boundary

This does **not** enable per-install feedback counts or last-active tracking. Those require a separate atomic, retryable storage design.

## Verification

- `npm run validate` — 99 test files, 1,530 tests passed
- Required PR review toolkit run against `origin/main`; focused independent reviewers report no remaining actionable findings
- Adversarial test covers an uninstall arriving during installation creation and verifies compensating deletion
- Pre-push TypeScript checks passed