### PR TITLE
Publish privacy-safe feedback issue count

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -135,9 +135,9 @@ so a delivery retry cannot increment the total twice. The tokens encode no accou
 repository, Issue, reporter, or submission information and are replaced as newer tokens
 arrive.
 
-These identifiers are used only to enforce submission limits and are not used for product
-analytics. Cloudflare may also temporarily process request and network metadata, including
-request paths, for service delivery, security, and operational logs.
+The rate-limit identifiers are used only to enforce submission limits and are not used for
+product analytics. Cloudflare may also temporarily process request and network metadata,
+including request paths, for service delivery, security, and operational logs.
 
 ## Retention
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-**Last updated:** August 28, 2026
+**Last updated:** August 30, 2026
 
 BugDrop is an open-source feedback widget that creates GitHub Issues. This policy covers
 the hosted BugDrop widget and service, as well as the BugDrop website at
@@ -130,6 +130,11 @@ The hosted service temporarily stores rate-limit counters to prevent abuse:
 - A counter keyed by the destination repository name expires one hour after its most
   recent update.
 
+The anonymous feedback total also retains up to 1,024 recent random deduplication tokens
+so a delivery retry cannot increment the total twice. The tokens encode no account,
+repository, Issue, reporter, or submission information and are replaced as newer tokens
+arrive.
+
 These identifiers are used only to enforce submission limits and are not used for product
 analytics. Cloudflare may also temporarily process request and network metadata, including
 request paths, for service delivery, security, and operational logs.
@@ -143,6 +148,7 @@ request paths, for service delivery, security, and operational logs.
   app is uninstalled. A scheduled cleanup independently removes records for installations
   GitHub no longer reports as active.
 - Anonymous aggregate totals may be retained indefinitely.
+- Random feedback-counter deduplication tokens are limited to the 1,024 most recent values.
 - Testimonial and contact information provided with explicit permission is retained until
   that permission is withdrawn or the information is no longer needed.
 - Website analytics identifiers stored in the browser remain until the visitor clears the

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -147,7 +147,12 @@ The only network requests BugDrop makes are:
 2. Submitting the feedback form to the BugDrop Cloudflare Worker API
 
 The API receives the form data, creates the issue and uploads its files, then discards the
-feedback content. The hosted service separately keeps short-lived rate-limit counters; see
+feedback content. After GitHub confirms Issue creation, the hosted service increments one
+anonymous global counter. The counter contains no account, repository, Issue, reporter, or
+submission data. To make delivery retries safe, it retains a bounded set of recent random
+deduplication tokens that encode no submission information. BugDrop excludes its first-party/test
+owners and publishes the total only as a rounded, defensible lower bound. The hosted service
+separately keeps short-lived rate-limit counters; see
 the [Privacy Policy](https://github.com/mean-weasel/bugdrop/blob/main/PRIVACY.md) for the
 complete data-handling and retention details.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import githubWebhook from './routes/github-webhook';
 import { createBoardDogfoodToken } from './lib/boardDogfood';
 import { sweepInstallationRecords } from './lib/installation-retention';
 
+export { FeedbackCounter } from './lib/feedback-counter';
+
 const app = new Hono<{ Bindings: Env }>();
 
 // Log warning about missing credentials (but don't block non-authenticated routes)

--- a/src/lib/feedback-counter.ts
+++ b/src/lib/feedback-counter.ts
@@ -1,0 +1,159 @@
+import type { Env } from '../types';
+
+const COUNTER_OBJECT_NAME = 'global-feedback-issues-created';
+const COUNTER_STORAGE_KEY = 'total';
+const RECENT_EVENT_IDS_STORAGE_KEY = 'recentEventIds';
+const MAX_RECENT_EVENT_IDS = 1024;
+const MAX_INCREMENT_ATTEMPTS = 3;
+const PUBLIC_BUCKET_SIZE = 100;
+
+type WaitUntilContext = {
+  readonly executionCtx: Pick<ExecutionContext, 'waitUntil'>;
+};
+
+export class FeedbackCounter {
+  constructor(
+    private readonly state: DurableObjectState,
+    private readonly env: Env
+  ) {}
+
+  async fetch(request: Request): Promise<Response> {
+    const pathname = new URL(request.url).pathname;
+    if (request.method === 'POST' && pathname === '/increment') {
+      const eventId = await parseEventId(request);
+      if (!eventId) return Response.json({ error: 'Invalid event ID' }, { status: 400 });
+
+      const total = await this.state.storage.transaction(async transaction => {
+        const current = await transaction.get<number>(COUNTER_STORAGE_KEY);
+        const recentEventIds =
+          (await transaction.get<string[]>(RECENT_EVENT_IDS_STORAGE_KEY)) ?? [];
+        if (recentEventIds.includes(eventId)) {
+          return current ?? getFeedbackCountBaseline(this.env);
+        }
+
+        const next = (current ?? getFeedbackCountBaseline(this.env)) + 1;
+        await transaction.put(COUNTER_STORAGE_KEY, next);
+        await transaction.put(
+          RECENT_EVENT_IDS_STORAGE_KEY,
+          [...recentEventIds, eventId].slice(-MAX_RECENT_EVENT_IDS)
+        );
+        return next;
+      });
+      return Response.json({ total });
+    }
+
+    if (request.method === 'GET' && pathname === '/total') {
+      const total =
+        (await this.state.storage.get<number>(COUNTER_STORAGE_KEY)) ??
+        getFeedbackCountBaseline(this.env);
+      return Response.json({ total });
+    }
+
+    return new Response('Not found', { status: 404 });
+  }
+}
+
+export function scheduleSuccessfulFeedbackCount(
+  env: Env,
+  repo: string,
+  context?: WaitUntilContext
+): void {
+  if (!env.FEEDBACK_COUNTER || isExcludedFromFeedbackCount(env, repo)) return;
+
+  const eventId = crypto.randomUUID();
+  const task = incrementFeedbackCount(env, eventId).catch(error => {
+    console.error('[BugDrop] Failed to increment anonymous feedback counter:', error);
+    throw error;
+  });
+
+  try {
+    if (context) {
+      context.executionCtx.waitUntil(task);
+    } else {
+      void task.catch(() => undefined);
+    }
+  } catch {
+    // Hono unit tests do not provide an ExecutionContext. The task has already
+    // started; prevent an unhandled rejection when no runtime can observe it.
+    void task.catch(() => undefined);
+  }
+}
+
+export async function getPublicFeedbackCount(env: Env): Promise<number | null> {
+  if (!env.FEEDBACK_COUNTER) {
+    return env.FEEDBACK_COUNT_BASELINE === undefined
+      ? null
+      : roundFeedbackCount(getFeedbackCountBaseline(env));
+  }
+
+  const response = await getCounterStub(env).fetch('https://feedback-counter/total');
+  if (!response.ok) throw new Error(`Feedback counter read failed with ${response.status}`);
+  const body = (await response.json()) as { total?: unknown };
+  if (!Number.isSafeInteger(body.total) || (body.total as number) < 0) {
+    throw new Error('Feedback counter returned an invalid total');
+  }
+  return roundFeedbackCount(body.total as number);
+}
+
+export function getFeedbackCountBaseline(env: Env): number {
+  const rawBaseline = env.FEEDBACK_COUNT_BASELINE ?? '0';
+  if (!/^\d+$/.test(rawBaseline)) return 0;
+  const baseline = Number.parseInt(rawBaseline, 10);
+  return Number.isSafeInteger(baseline) && baseline >= 0 ? baseline : 0;
+}
+
+export function roundFeedbackCount(total: number): number {
+  return Math.floor(total / PUBLIC_BUCKET_SIZE) * PUBLIC_BUCKET_SIZE;
+}
+
+export function isExcludedFromFeedbackCount(env: Env, repo: string): boolean {
+  const [owner] = repo.split('/');
+  if (!owner) return true;
+  const excludedOwners = new Set(
+    (env.FEEDBACK_COUNT_EXCLUDED_OWNERS ?? '')
+      .split(',')
+      .map(value => value.trim().toLowerCase())
+      .filter(Boolean)
+  );
+  return excludedOwners.has(owner.toLowerCase());
+}
+
+async function incrementFeedbackCount(env: Env, eventId: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_INCREMENT_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await getCounterStub(env).fetch('https://feedback-counter/increment', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventId }),
+      });
+      if (!response.ok) {
+        throw new Error(`Feedback counter increment failed with ${response.status}`);
+      }
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error('Feedback counter increment failed');
+}
+
+async function parseEventId(request: Request): Promise<string | null> {
+  try {
+    const body = (await request.json()) as { eventId?: unknown };
+    return typeof body.eventId === 'string' &&
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        body.eventId
+      )
+      ? body.eventId
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function getCounterStub(env: Env): DurableObjectStub {
+  const namespace = env.FEEDBACK_COUNTER;
+  if (!namespace) throw new Error('Feedback counter binding is unavailable');
+  return namespace.get(namespace.idFromName(COUNTER_OBJECT_NAME));
+}

--- a/src/lib/github-issue-result.ts
+++ b/src/lib/github-issue-result.ts
@@ -1,0 +1,34 @@
+import type { GitHubIssue } from '../types';
+
+export function isCanonicalGitHubIssue(
+  issue: unknown,
+  owner: string,
+  repo: string
+): issue is GitHubIssue {
+  if (typeof issue !== 'object' || issue === null) return false;
+
+  const candidate = issue as Partial<GitHubIssue>;
+  if (
+    !Number.isInteger(candidate.number) ||
+    (candidate.number as number) <= 0 ||
+    typeof candidate.html_url !== 'string'
+  ) {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(candidate.html_url);
+    const expectedPath = `/${owner}/${repo}/issues/${candidate.number}`.toLocaleLowerCase('en-US');
+    return (
+      parsed.protocol === 'https:' &&
+      parsed.hostname === 'github.com' &&
+      parsed.username === '' &&
+      parsed.password === '' &&
+      parsed.search === '' &&
+      parsed.hash === '' &&
+      parsed.pathname.toLocaleLowerCase('en-US') === expectedPath
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -26,6 +26,8 @@ import {
 } from '../lib/markdown';
 import { handleStructuredFeedback, isStructuredFeedbackRequest } from './structured-feedback';
 import { parseAppVersion } from '../app-version';
+import { getPublicFeedbackCount, scheduleSuccessfulFeedbackCount } from '../lib/feedback-counter';
+import { isCanonicalGitHubIssue } from '../lib/github-issue-result';
 
 type ApiVariables = {
   feedbackPayload?: unknown;
@@ -129,6 +131,63 @@ api.get('/health', c => {
     capabilities: { appVersionMetadata: true },
     ...(buildSha ? { buildSha } : {}),
   });
+});
+
+api.get('/stats/feedback-issues', async c => {
+  const cacheUrl = new URL(c.req.url);
+  cacheUrl.search = '';
+  cacheUrl.hash = '';
+  const cacheKey = new Request(cacheUrl, { method: 'GET' });
+  const sharedCache = typeof caches === 'undefined' ? undefined : caches.default;
+  if (sharedCache) {
+    try {
+      const cached = await sharedCache.match(cacheKey);
+      if (cached) {
+        const response = new Response(cached.body, cached);
+        // CORS is request-specific and is reapplied by the outer middleware.
+        response.headers.delete('Access-Control-Allow-Origin');
+        response.headers.delete('Access-Control-Allow-Credentials');
+        response.headers.delete('Vary');
+        return response;
+      }
+    } catch (error) {
+      console.warn('[BugDrop] Failed to read cached public feedback count:', error);
+    }
+  }
+
+  try {
+    const feedbackIssuesCreated = await getPublicFeedbackCount(c.env);
+    if (feedbackIssuesCreated === null) {
+      return c.json({ error: 'Feedback count unavailable' }, 503, {
+        'Cache-Control': 'no-store',
+      });
+    }
+    const response = Response.json(
+      {
+        feedbackIssuesCreated,
+        display: `${feedbackIssuesCreated.toLocaleString('en-US')}+`,
+      },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': 'public, max-age=3600, s-maxage=86400, stale-while-revalidate=86400',
+        },
+      }
+    );
+    if (sharedCache) {
+      try {
+        await sharedCache.put(cacheKey, response.clone());
+      } catch (error) {
+        console.warn('[BugDrop] Failed to cache public feedback count:', error);
+      }
+    }
+    return response;
+  } catch (error) {
+    console.error('[BugDrop] Failed to read anonymous feedback counter:', error);
+    return c.json({ error: 'Feedback count unavailable' }, 503, {
+      'Cache-Control': 'no-store',
+    });
+  }
 });
 
 function getBuildSha(env: Env): string | undefined {
@@ -306,6 +365,12 @@ api.post('/feedback', async c => {
         );
       }
     }
+
+    if (!isCanonicalGitHubIssue(issue, owner, repo)) {
+      throw new Error('GitHub returned an invalid Issue result');
+    }
+
+    scheduleSuccessfulFeedbackCount(c.env, payload.repo, c);
 
     return c.json({
       success: true,

--- a/src/routes/structured-feedback.ts
+++ b/src/routes/structured-feedback.ts
@@ -14,6 +14,8 @@ import type {
   StructuredFeedbackSectionFormat,
 } from '../types';
 import { parseAppVersion } from '../app-version';
+import { scheduleSuccessfulFeedbackCount } from '../lib/feedback-counter';
+import { isCanonicalGitHubIssue } from '../lib/github-issue-result';
 
 const STRUCTURED_KIND = 'bugdrop.variant-submission';
 const STRUCTURED_SCHEMA_VERSION = 1;
@@ -144,13 +146,11 @@ export async function handleStructuredFeedback(c: StructuredContext, input: unkn
       issue = await createIssue(token, owner, repo, payload.issue.title, body, fallbackLabels);
     }
 
-    if (
-      !Number.isInteger(issue.number) ||
-      issue.number <= 0 ||
-      !isCanonicalIssueUrl(issue.html_url, owner, repo, issue.number)
-    ) {
+    if (!isCanonicalGitHubIssue(issue, owner, repo)) {
       throw new Error('GitHub returned an invalid Issue result');
     }
+
+    scheduleSuccessfulFeedbackCount(c.env, payload.repo, c);
 
     return c.json({
       success: true,
@@ -592,29 +592,6 @@ function formatInlineCode(value: string): string {
 
 function formatLabelList(labels: string[]): string {
   return labels.map(formatInlineCode).join(', ');
-}
-
-function isCanonicalIssueUrl(
-  url: string,
-  owner: string,
-  repo: string,
-  issueNumber: number
-): boolean {
-  try {
-    const parsed = new URL(url);
-    const expectedPath = `/${owner}/${repo}/issues/${issueNumber}`.toLocaleLowerCase('en-US');
-    return (
-      parsed.protocol === 'https:' &&
-      parsed.hostname === 'github.com' &&
-      parsed.username === '' &&
-      parsed.password === '' &&
-      parsed.search === '' &&
-      parsed.hash === '' &&
-      parsed.pathname.toLocaleLowerCase('en-US') === expectedPath
-    );
-  } catch {
-    return false;
-  }
 }
 
 function collapseWhitespace(value: string): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,11 +25,14 @@ export interface Env {
   BUGDROP_BOARD_APP_ID?: string; // Optional hosted beta app claim for the demo board token
   BUGDROP_BOARD_TOKEN_AUDIENCE?: string; // Optional override for board token audience
   BUGDROP_BOARD_TOKEN_ISSUER?: string; // Optional override for board token issuer
+  FEEDBACK_COUNT_BASELINE?: string; // Anonymous external-Issue count before live counting
+  FEEDBACK_COUNT_EXCLUDED_OWNERS?: string; // Comma-separated first-party/test owners
 
   // Bindings
   ASSETS: Fetcher;
   RATE_LIMIT?: KVNamespace; // Optional: for rate limiting (create with wrangler kv:namespace create RATE_LIMIT)
   INSTALLATION_ANALYTICS?: KVNamespace; // Minimal installation identity records
+  FEEDBACK_COUNTER?: DurableObjectNamespace; // Anonymous global successful-Issue counter
 }
 
 export type FeedbackCategory = 'bug' | 'feature' | 'question';

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import type { Env, FeedbackPayload } from '../src/types';
 import { createBugDropAuthTokenForTest } from '../src/lib/authToken';
@@ -81,6 +81,10 @@ describe('API Routes', () => {
     app = await createApiRoutes();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe('GET /health', () => {
     it('should return status ok', async () => {
       const req = new Request('http://localhost/health');
@@ -128,6 +132,64 @@ describe('API Routes', () => {
 
         expect(data).not.toHaveProperty('buildSha');
       }
+    });
+  });
+
+  describe('GET /stats/feedback-issues', () => {
+    it('returns only the rounded public count with daily shared caching', async () => {
+      const put = vi.fn().mockResolvedValue(undefined);
+      const match = vi.fn().mockResolvedValue(undefined);
+      vi.stubGlobal('caches', { default: { match, put } });
+      const req = new Request('http://localhost/stats/feedback-issues?nonce=ignored', {
+        headers: { Origin: 'https://first.example' },
+      });
+      const res = await app.fetch(req, { ...mockEnv, FEEDBACK_COUNT_BASELINE: '3116' });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        feedbackIssuesCreated: 3100,
+        display: '3,100+',
+      });
+      expect(res.headers.get('Cache-Control')).toContain('s-maxage=86400');
+      expect(match).toHaveBeenCalledOnce();
+      expect(put).toHaveBeenCalledOnce();
+      expect((match.mock.calls[0][0] as Request).url).toBe(
+        'http://localhost/stats/feedback-issues'
+      );
+      const storedResponse = put.mock.calls[0][1] as Response;
+      expect(storedResponse.headers.get('Access-Control-Allow-Origin')).toBeNull();
+
+      const cachedResponse = Response.json(
+        {
+          feedbackIssuesCreated: 3100,
+          display: '3,100+',
+        },
+        {
+          headers: { 'Access-Control-Allow-Origin': 'https://first.example' },
+        }
+      );
+      match.mockResolvedValueOnce(cachedResponse);
+      const cached = await app.fetch(
+        new Request('http://localhost/stats/feedback-issues?another=ignored', {
+          headers: { Origin: 'https://second.example' },
+        }),
+        mockEnv
+      );
+      expect(await cached.json()).toEqual({
+        feedbackIssuesCreated: 3100,
+        display: '3,100+',
+      });
+      expect(cached.headers.get('Access-Control-Allow-Origin')).toBe('https://second.example');
+      expect(put).toHaveBeenCalledOnce();
+    });
+
+    it('fails closed without exposing a synthetic count when unconfigured', async () => {
+      const req = new Request('http://localhost/stats/feedback-issues');
+      const res = await app.fetch(req, mockEnv);
+
+      expect(res.status).toBe(503);
+      expect(await res.json()).toEqual({ error: 'Feedback count unavailable' });
+      expect(res.headers.get('Cache-Control')).toBe('no-store');
     });
   });
 
@@ -368,6 +430,92 @@ describe('API Routes', () => {
         expect.stringContaining('This is a test feedback'),
         ['bug', 'bugdrop']
       );
+    });
+
+    it('queues one anonymous counter increment only after GitHub creates the Issue', async () => {
+      const counterFetch = vi.fn().mockResolvedValue(Response.json({ total: 3117 }));
+      const counterId = {} as DurableObjectId;
+      const waitUntil = vi.fn();
+      const env = {
+        ...mockEnv,
+        FEEDBACK_COUNTER: {
+          idFromName: vi.fn().mockReturnValue(counterId),
+          get: vi.fn().mockReturnValue({ fetch: counterFetch }),
+        } as unknown as DurableObjectNamespace,
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+
+      const res = await app.fetch(req, env, { waitUntil } as unknown as ExecutionContext);
+
+      expect(res.status).toBe(200);
+      expect(waitUntil).toHaveBeenCalledOnce();
+      await (waitUntil.mock.calls[0][0] as Promise<void>);
+      expect(counterFetch).toHaveBeenCalledOnce();
+      expect(counterFetch).toHaveBeenCalledWith(
+        'https://feedback-counter/increment',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: expect.stringMatching(/"eventId":"[0-9a-f-]{36}"/i),
+        })
+      );
+    });
+
+    it('does not count feedback when GitHub Issue creation fails', async () => {
+      mockCreateIssue.mockRejectedValueOnce(new Error('GitHub unavailable'));
+      const counterFetch = vi.fn();
+      const counterId = {} as DurableObjectId;
+      const waitUntil = vi.fn();
+      const env = {
+        ...mockEnv,
+        FEEDBACK_COUNTER: {
+          idFromName: vi.fn().mockReturnValue(counterId),
+          get: vi.fn().mockReturnValue({ fetch: counterFetch }),
+        } as unknown as DurableObjectNamespace,
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+
+      const res = await app.fetch(req, env, { waitUntil } as unknown as ExecutionContext);
+
+      expect(res.status).toBe(500);
+      expect(counterFetch).not.toHaveBeenCalled();
+      expect(waitUntil).not.toHaveBeenCalled();
+    });
+
+    it('does not count a malformed GitHub success response', async () => {
+      mockCreateIssue.mockResolvedValueOnce({
+        number: 42,
+        html_url: 'https://github.com/another/repo/issues/42',
+      });
+      const counterFetch = vi.fn();
+      const waitUntil = vi.fn();
+      const env = {
+        ...mockEnv,
+        FEEDBACK_COUNTER: {
+          idFromName: vi.fn().mockReturnValue({} as DurableObjectId),
+          get: vi.fn().mockReturnValue({ fetch: counterFetch }),
+        } as unknown as DurableObjectNamespace,
+      };
+      const req = new Request('http://localhost/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validPayload),
+      });
+
+      const res = await app.fetch(req, env, { waitUntil } as unknown as ExecutionContext);
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: 'GitHub returned an invalid Issue result' });
+      expect(counterFetch).not.toHaveBeenCalled();
+      expect(waitUntil).not.toHaveBeenCalled();
     });
 
     it('should expose the configured Worker build SHA on successful feedback', async () => {

--- a/test/feedbackCounter.test.ts
+++ b/test/feedbackCounter.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/types';
+import {
+  FeedbackCounter,
+  getFeedbackCountBaseline,
+  getPublicFeedbackCount,
+  isExcludedFromFeedbackCount,
+  roundFeedbackCount,
+  scheduleSuccessfulFeedbackCount,
+} from '../src/lib/feedback-counter';
+
+const baseEnv: Env = {
+  GITHUB_APP_ID: 'test-app-id',
+  GITHUB_PRIVATE_KEY: 'test-private-key',
+  ENVIRONMENT: 'test',
+  ALLOWED_ORIGINS: '*',
+  GITHUB_APP_NAME: 'test-bugdrop-app',
+  MAX_SCREENSHOT_SIZE_MB: '5',
+  ASSETS: {} as Fetcher,
+};
+
+describe('anonymous feedback counter', () => {
+  it('initializes from the audited baseline and stores no identifying values', async () => {
+    const values = new Map<string, unknown>();
+    const storage = createStorage(values);
+    const counter = new FeedbackCounter({ storage } as unknown as DurableObjectState, {
+      ...baseEnv,
+      FEEDBACK_COUNT_BASELINE: '3116',
+    });
+
+    const firstEventId = '11111111-1111-4111-8111-111111111111';
+    const secondEventId = '22222222-2222-4222-8222-222222222222';
+    const first = await counter.fetch(incrementRequest(firstEventId));
+    const second = await counter.fetch(incrementRequest(secondEventId));
+
+    expect(await first.json()).toEqual({ total: 3117 });
+    expect(await second.json()).toEqual({ total: 3118 });
+    expect(values.get('total')).toBe(3118);
+    expect(values.get('recentEventIds')).toEqual([firstEventId, secondEventId]);
+    expect(JSON.stringify([...values.values()])).not.toContain('external/app');
+  });
+
+  it('deduplicates an ambiguous retry using the same opaque event ID', async () => {
+    const values = new Map<string, unknown>();
+    const counter = new FeedbackCounter(
+      { storage: createStorage(values) } as unknown as DurableObjectState,
+      { ...baseEnv, FEEDBACK_COUNT_BASELINE: '3116' }
+    );
+    const eventId = '11111111-1111-4111-8111-111111111111';
+
+    const first = await counter.fetch(incrementRequest(eventId));
+    const retry = await counter.fetch(incrementRequest(eventId));
+
+    expect(await first.json()).toEqual({ total: 3117 });
+    expect(await retry.json()).toEqual({ total: 3117 });
+    expect(values.get('total')).toBe(3117);
+  });
+
+  it('publishes only a rounded-down bucket', async () => {
+    const fetch = vi.fn().mockResolvedValue(Response.json({ total: 3199 }));
+    const env = { ...baseEnv, FEEDBACK_COUNTER: createNamespace(fetch) };
+
+    await expect(getPublicFeedbackCount(env)).resolves.toBe(3100);
+    expect(fetch).toHaveBeenCalledWith('https://feedback-counter/total');
+    expect(roundFeedbackCount(3200)).toBe(3200);
+  });
+
+  it('uses a rounded baseline when the binding is intentionally absent', async () => {
+    await expect(
+      getPublicFeedbackCount({ ...baseEnv, FEEDBACK_COUNT_BASELINE: '3116' })
+    ).resolves.toBe(3100);
+    await expect(getPublicFeedbackCount(baseEnv)).resolves.toBeNull();
+  });
+
+  it('excludes configured first-party owners without persisting repository identity', () => {
+    const env = {
+      ...baseEnv,
+      FEEDBACK_COUNT_EXCLUDED_OWNERS: 'mean-weasel, NeonWatty',
+    };
+
+    expect(isExcludedFromFeedbackCount(env, 'mean-weasel/bugdrop')).toBe(true);
+    expect(isExcludedFromFeedbackCount(env, 'neonwatty/test-repo')).toBe(true);
+    expect(isExcludedFromFeedbackCount(env, 'external/app')).toBe(false);
+  });
+
+  it('isolates counter failures from successful feedback responses', async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error('counter unavailable'));
+    const waitUntil = vi.fn();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const env = { ...baseEnv, FEEDBACK_COUNTER: createNamespace(fetch) };
+
+    expect(() =>
+      scheduleSuccessfulFeedbackCount(env, 'external/app', {
+        executionCtx: { waitUntil },
+      })
+    ).not.toThrow();
+
+    const queued = waitUntil.mock.calls[0][0] as Promise<void>;
+    await expect(queued).rejects.toThrow('counter unavailable');
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(error).toHaveBeenCalledWith(
+      '[BugDrop] Failed to increment anonymous feedback counter:',
+      expect.any(Error)
+    );
+    error.mockRestore();
+  });
+
+  it('reuses one opaque event ID when retrying an ambiguous delivery failure', async () => {
+    const fetch = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('response lost'))
+      .mockResolvedValueOnce(Response.json({ total: 3117 }));
+    const waitUntil = vi.fn();
+    const env = { ...baseEnv, FEEDBACK_COUNTER: createNamespace(fetch) };
+
+    scheduleSuccessfulFeedbackCount(env, 'external/app', {
+      executionCtx: { waitUntil },
+    });
+    await (waitUntil.mock.calls[0][0] as Promise<void>);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const firstBody = (fetch.mock.calls[0][1] as RequestInit).body;
+    const retryBody = (fetch.mock.calls[1][1] as RequestInit).body;
+    expect(firstBody).toBe(retryBody);
+  });
+
+  it('does not schedule counter work for excluded owners', () => {
+    const fetch = vi.fn();
+    const waitUntil = vi.fn();
+    const env = {
+      ...baseEnv,
+      FEEDBACK_COUNTER: createNamespace(fetch),
+      FEEDBACK_COUNT_EXCLUDED_OWNERS: 'mean-weasel',
+    };
+
+    scheduleSuccessfulFeedbackCount(env, 'mean-weasel/bugdrop', {
+      executionCtx: { waitUntil },
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [undefined, 0],
+    ['3116', 3116],
+    ['invalid', 0],
+    ['3116issues', 0],
+    ['-1', 0],
+  ])('normalizes baseline %s to %d', (value, expected) => {
+    expect(getFeedbackCountBaseline({ ...baseEnv, FEEDBACK_COUNT_BASELINE: value })).toBe(expected);
+  });
+});
+
+function incrementRequest(eventId: string): Request {
+  return new Request('https://feedback-counter/increment', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventId }),
+  });
+}
+
+function createNamespace(fetch: ReturnType<typeof vi.fn>): DurableObjectNamespace {
+  const id = {} as DurableObjectId;
+  return {
+    idFromName: vi.fn().mockReturnValue(id),
+    get: vi.fn().mockReturnValue({ fetch }),
+  } as unknown as DurableObjectNamespace;
+}
+
+function createStorage(values: Map<string, unknown>): DurableObjectStorage {
+  return {
+    get: async <T>(key: string) => values.get(key) as T | undefined,
+    transaction: async <T>(
+      closure: (transaction: DurableObjectTransaction) => Promise<T>
+    ): Promise<T> =>
+      closure({
+        get: async <Value>(key: string) => values.get(key) as Value | undefined,
+        put: async <Value>(key: string, value: Value) => {
+          values.set(key, value);
+        },
+      } as DurableObjectTransaction),
+  } as DurableObjectStorage;
+}

--- a/test/structuredFeedback.test.ts
+++ b/test/structuredFeedback.test.ts
@@ -134,6 +134,32 @@ describe('structured feedback Worker contract', () => {
     expect(mockGetInstallationToken).toHaveBeenCalledOnce();
   });
 
+  it('queues one anonymous counter increment after a valid structured Issue result', async () => {
+    const counterFetch = vi.fn().mockResolvedValue(Response.json({ total: 3117 }));
+    const counterId = {} as DurableObjectId;
+    const waitUntil = vi.fn();
+    const counterEnv = {
+      ...env,
+      FEEDBACK_COUNTER: {
+        idFromName: vi.fn().mockReturnValue(counterId),
+        get: vi.fn().mockReturnValue({ fetch: counterFetch }),
+      } as unknown as DurableObjectNamespace,
+    };
+    const request = new Request('http://localhost/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validPayload),
+    });
+
+    const response = await app.fetch(request, counterEnv, {
+      waitUntil,
+    } as unknown as ExecutionContext);
+
+    expect(response.status).toBe(200);
+    await (waitUntil.mock.calls[0][0] as Promise<void>);
+    expect(counterFetch).toHaveBeenCalledOnce();
+  });
+
   it('omits App Version when metadata does not provide one', async () => {
     const payload = structuredClone(validPayload);
     delete payload.metadata.appVersion;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,6 +8,7 @@ routes = [
   { pattern = "bugdrop.dev/board-dogfood*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/api/bugdrop-board-token*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/api/github/webhook*", zone_name = "bugdrop.dev" },
+  { pattern = "bugdrop.dev/api/stats/feedback-issues*", zone_name = "bugdrop.dev" },
 ]
 
 [triggers]
@@ -26,6 +27,15 @@ GITHUB_APP_NAME = "neonwatty-bugdrop"  # Your GitHub App's URL slug
 MAX_SCREENSHOT_SIZE_MB = "5"  # Maximum screenshot size in MB
 BUGDROP_BOARD_TENANT_ID = "tenant_mean_weasel"
 BUGDROP_BOARD_APP_ID = "app_mean_weasel_bugdrop_dogfood"
+FEEDBACK_COUNT_BASELINE = "0"
+FEEDBACK_COUNT_EXCLUDED_OWNERS = "mean-weasel,neonwatty"
+
+[durable_objects]
+bindings = [{ name = "FEEDBACK_COUNTER", class_name = "FeedbackCounter" }]
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["FeedbackCounter"]
 
 # Rate limiting KV namespace
 [[kv_namespaces]]
@@ -56,6 +66,11 @@ ENVIRONMENT = "preview"
 ALLOWED_ORIGINS = "*"
 GITHUB_APP_NAME = "neonwatty-bugdrop"
 MAX_SCREENSHOT_SIZE_MB = "5"
+FEEDBACK_COUNT_BASELINE = "0"
+FEEDBACK_COUNT_EXCLUDED_OWNERS = "mean-weasel,neonwatty"
+
+[env.preview.durable_objects]
+bindings = [{ name = "FEEDBACK_COUNTER", class_name = "FeedbackCounter" }]
 
 [[env.preview.kv_namespaces]]
 binding = "RATE_LIMIT"
@@ -75,6 +90,7 @@ routes = [
   { pattern = "bugdrop.dev/board-dogfood*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/api/bugdrop-board-token*", zone_name = "bugdrop.dev" },
   { pattern = "bugdrop.dev/api/github/webhook*", zone_name = "bugdrop.dev" },
+  { pattern = "bugdrop.dev/api/stats/feedback-issues*", zone_name = "bugdrop.dev" },
 ]
 
 [env.production.triggers]
@@ -91,6 +107,11 @@ GITHUB_APP_NAME = "neonwatty-bugdrop"
 MAX_SCREENSHOT_SIZE_MB = "5"
 BUGDROP_BOARD_TENANT_ID = "tenant_mean_weasel"
 BUGDROP_BOARD_APP_ID = "app_mean_weasel_bugdrop_dogfood"
+FEEDBACK_COUNT_BASELINE = "3116"
+FEEDBACK_COUNT_EXCLUDED_OWNERS = "mean-weasel,neonwatty"
+
+[env.production.durable_objects]
+bindings = [{ name = "FEEDBACK_COUNTER", class_name = "FeedbackCounter" }]
 
 [[env.production.kv_namespaces]]
 binding = "RATE_LIMIT"


### PR DESCRIPTION
## Summary
- count successful external GitHub Issue creations in an anonymous global Durable Object
- publish only a rounded, daily-cached lower-bound statistic
- document the audited 3,116 baseline, exclusions, retry deduplication, and privacy handling

## Verification
- `pnpm run validate` (100 files, 1,549 tests)
- `wrangler deploy --dry-run --env preview`
- `wrangler deploy --dry-run --env production`
- independent correctness, test-coverage, and simplification reviews: clear