### PR TITLE
feat: count feedback by GitHub installation

### DIFF
--- a/docs/installation-usage-counting.md
+++ b/docs/installation-usage-counting.md
@@ -1,0 +1,61 @@
+# Per-installation successful feedback counts
+
+BugDrop can privately count successful GitHub Issues per GitHub App installation without adding a
+database. The feature reuses the existing `FEEDBACK_COUNTER` Durable Object namespace for atomic
+counts and asynchronously mirrors the latest durable integer into the existing
+`INSTALLATION_ANALYTICS` KV namespace for the operator-only consent review.
+
+## Data boundary
+
+Each usage record contains exactly:
+
+```json
+{
+  "schemaVersion": 1,
+  "installationId": 123,
+  "successfulFeedbackCount": 7
+}
+```
+
+The count covers successful feedback Issues created in every repository available through that
+installation. It is prospective and does not backfill older Issues. BugDrop does not store the
+repository, Issue contents, reporter, submission timestamp, or last-active date in this record.
+The public aggregate feedback counter remains separate and rounded.
+
+## Activation and rollback
+
+Collection is off unless `INSTALLATION_USAGE_ENABLED` is exactly `true`. Do not enable it until the
+published privacy policy accurately discloses the purpose, fields, retention, and deletion behavior.
+Turning the setting off immediately stops accepting new per-installation events without affecting
+the public anonymous total. A count already accepted by the Durable Object may finish mirroring to
+KV. Keep the existing `FEEDBACK_COUNTER` binding available after activation so uninstall cleanup
+can remove previously stored durable counts.
+
+After enabling it, dogfood one controlled installation and verify that its private record has only
+the three allowed fields above. Uninstall it and verify that the identity, usage mirror, and atomic
+counter are removed.
+
+## Deletion behavior
+
+While collection is enabled, an uninstall webhook or retention sweep first writes a seven-day
+opaque KV deletion guard, then sets a strongly consistent seven-day deletion marker in the
+installation's Durable Object. It then deletes the atomic count and KV usage mirror, and removes the
+installation identity last. This order makes a partial cleanup retryable and prevents a delayed
+in-flight submission from recreating usage after uninstall. While collection is disabled, cleanup
+hard-purges any old counter and mirror without creating those guards. No installation ID or account
+identity is exposed through a public endpoint.
+
+The Durable Object coalesces bursts into a single delayed KV write, avoiding Workers KV's
+same-key write-rate limit. Its alarm retries a failed mirror write; the operator view can lag a
+successful submission briefly while the durable count remains authoritative.
+
+The mirror is not created until the installation identity record is visible. If that record is
+still propagating, the Durable Object makes at most 1,440 one-minute retry checks without resetting
+the original budget. The budget is a non-temporal integer; no submission timestamp is stored. If no
+identity arrives, it purges the unanchored counter instead of retaining usage that the scheduled
+cleanup cannot discover. This intentionally favors deletion safety over completeness for a
+pre-tracking installation or a permanently missed installation-created webhook.
+
+Delivery uses one opaque event ID across retries, so an ambiguous retry does not increment twice.
+It has the same best-effort delivery boundary as the existing anonymous public counter; it is not a
+billing ledger.

--- a/docs/social-proof-consent.md
+++ b/docs/social-proof-consent.md
@@ -12,8 +12,9 @@ authorizes public display from an installation alone.
   inside the repository, including paths reached through a symlinked parent directory, and refuses
   input files readable or writable by other users.
 - Never commit the registry, fingerprint key, permission evidence, or installation identities.
-- Do not add repository information, usage frequency, issue counts, email addresses, or other
-  enrichment to this workflow.
+- Do not add repository information, issue contents, reporter details, email addresses, last-active
+  dates, or other enrichment to this workflow. The only allowed usage signal is the exact count of
+  successful feedback Issues associated with an installation.
 - Contact an app owner at most once unless they reply. Record `contacted`, `declined`, `approved`,
   or `withdrawn` before reviewing candidates again.
 - Publishing requires affirmative permission from an authorized representative. Copy only the
@@ -45,11 +46,13 @@ npm run social-proof:consent -- review \
   --exclude mean-weasel,neonwatty
 ```
 
-The private terminal displays the currently eligible account, profile, installation date, and its
-keyed fingerprint. The command does not save those installation identities to another file. Close
-the terminal session after finishing the review. The command rejects installation records with any
-fields beyond the approved minimal schema. The exclusion list is required so owned and controlled
-test accounts cannot accidentally enter the outreach queue.
+The private terminal displays the currently eligible account, profile, installation date, keyed
+fingerprint, and—when collection was enabled for that installation—the successful-feedback count.
+Known counts are ranked highest first; a missing count is not presented as zero. The command does
+not save installation identities or usage counts to another file. Close the terminal session after
+finishing the review. The command rejects identity and usage records with any fields beyond their
+approved minimal schemas. The exclusion list is required so owned and controlled test accounts
+cannot accidentally enter the outreach queue.
 
 ## Record decisions
 
@@ -80,6 +83,6 @@ npm run social-proof:consent -- export-approved \
   --output /private/path/bugdrop-approved-social-proof.json
 ```
 
-This export contains only approved public profile fields. It omits account fingerprints, private
-evidence references, contact status, and all unapproved apps. Review the output against the
-permission evidence before copying it into the website repository.
+This export contains only approved public profile fields. It omits account fingerprints, usage
+counts, private evidence references, contact status, and all unapproved apps. Review the output
+against the permission evidence before copying it into the website repository.

--- a/scripts/social-proof-consent-lib.mjs
+++ b/scripts/social-proof-consent-lib.mjs
@@ -74,7 +74,7 @@ export function buildCandidateReview(
   return { schemaVersion: 1, generatedAt, candidates };
 }
 
-export function validateInstallationUsageRecord(record) {
+function validateInstallationUsageRecord(record) {
   if (
     !isObject(record) ||
     !hasExactKeys(record, ['schemaVersion', 'installationId', 'successfulFeedbackCount']) ||

--- a/scripts/social-proof-consent-lib.mjs
+++ b/scripts/social-proof-consent-lib.mjs
@@ -27,20 +27,33 @@ export function buildCandidateReview(
   registry,
   excludedLogins,
   fingerprintKey,
-  generatedAt = new Date().toISOString()
+  generatedAt = new Date().toISOString(),
+  usageRecords = []
 ) {
   validateRegistry(registry);
   validateRegistryKey(registry, fingerprintKey);
   assertIsoDate(generatedAt);
   const excluded = new Set(validateExcludedLogins(excludedLogins));
+  const usageByInstallation = new Map();
+  for (const record of usageRecords) {
+    const valid = validateInstallationUsageRecord(record);
+    if (usageByInstallation.has(valid.installationId)) {
+      throw new Error('Duplicate installation usage record');
+    }
+    usageByInstallation.set(valid.installationId, valid.successfulFeedbackCount);
+  }
   const decided = registry.entries.map(entry => Buffer.from(entry.accountFingerprint, 'hex'));
   const eligible = records
     .map(validateInstallationRecord)
-    .map(record => ({
-      account: record.account,
-      installedAt: record.installedAt,
-      accountFingerprint: fingerprintAccount(record.account.login, fingerprintKey),
-    }))
+    .map(record => {
+      const successfulFeedbackCount = usageByInstallation.get(record.installationId);
+      return {
+        account: record.account,
+        installedAt: record.installedAt,
+        accountFingerprint: fingerprintAccount(record.account.login, fingerprintKey),
+        ...(successfulFeedbackCount === undefined ? {} : { successfulFeedbackCount }),
+      };
+    })
     .filter(
       record =>
         !excluded.has(record.account.login.toLocaleLowerCase('en-US')) &&
@@ -56,11 +69,24 @@ export function buildCandidateReview(
       candidatesByAccount.set(candidate.accountFingerprint, candidate);
     }
   }
-  const candidates = [...candidatesByAccount.values()].sort((a, b) =>
-    a.installedAt.localeCompare(b.installedAt)
-  );
+  const candidates = [...candidatesByAccount.values()].sort(compareCandidatePriority);
 
   return { schemaVersion: 1, generatedAt, candidates };
+}
+
+export function validateInstallationUsageRecord(record) {
+  if (
+    !isObject(record) ||
+    !hasExactKeys(record, ['schemaVersion', 'installationId', 'successfulFeedbackCount']) ||
+    record.schemaVersion !== 1
+  ) {
+    throw new Error('Invalid installation usage record');
+  }
+  assertPositiveInteger(record.installationId);
+  if (!Number.isSafeInteger(record.successfulFeedbackCount) || record.successfulFeedbackCount < 0) {
+    throw new Error('Invalid installation usage record');
+  }
+  return record;
 }
 
 export function buildApprovedExport(registry, generatedAt = new Date().toISOString()) {
@@ -191,6 +217,16 @@ function validateInstallationRecord(record) {
     throw new Error('Invalid installation record');
   }
   return record;
+}
+
+function compareCandidatePriority(a, b) {
+  const aKnown = Number.isSafeInteger(a.successfulFeedbackCount);
+  const bKnown = Number.isSafeInteger(b.successfulFeedbackCount);
+  if (aKnown !== bKnown) return aKnown ? -1 : 1;
+  if (aKnown && a.successfulFeedbackCount !== b.successfulFeedbackCount) {
+    return b.successfulFeedbackCount - a.successfulFeedbackCount;
+  }
+  return b.installedAt.localeCompare(a.installedAt);
 }
 
 function normalizeGitHubLogin(value) {

--- a/scripts/social-proof-consent.mjs
+++ b/scripts/social-proof-consent.mjs
@@ -16,6 +16,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 const INSTALLATION_PREFIX = 'installation:';
+const INSTALLATION_USAGE_PREFIX = 'installation-usage:';
 const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 async function readInstallationRecords() {
@@ -38,10 +39,13 @@ async function readInstallationRecords() {
     const keys = JSON.parse(listed.stdout);
     if (!Array.isArray(keys)) throw new Error('invalid list');
 
-    const records = [];
+    const installations = [];
+    const usageRecords = [];
     for (const item of keys) {
       if (!isObject(item) || typeof item.name !== 'string') throw new Error('invalid key');
-      if (!item.name.startsWith(INSTALLATION_PREFIX)) continue;
+      const isInstallation = item.name.startsWith(INSTALLATION_PREFIX);
+      const isUsage = item.name.startsWith(INSTALLATION_USAGE_PREFIX);
+      if (!isInstallation && !isUsage) continue;
       const result = await execFileAsync(
         wrangler,
         [
@@ -58,9 +62,11 @@ async function readInstallationRecords() {
         ],
         { cwd: REPOSITORY_ROOT, maxBuffer: 1024 * 1024 }
       );
-      records.push(JSON.parse(result.stdout));
+      const record = JSON.parse(result.stdout);
+      if (isUsage) usageRecords.push(record);
+      else installations.push(record);
     }
-    return records;
+    return { installations, usageRecords };
   } catch {
     throw new Error('Unable to read installation records from Cloudflare KV');
   }
@@ -178,8 +184,17 @@ export async function runCli(args, dependencies = {}) {
     const registry = await readRegistry(options.registry);
     const fingerprintKey = await readFingerprintKey(options.key);
     validateRegistryKey(registry, fingerprintKey);
-    const records = await readRecords();
-    const review = buildCandidateReview(records, registry, excludedLogins, fingerprintKey);
+    const result = await readRecords();
+    const installations = Array.isArray(result) ? result : result.installations;
+    const usageRecords = Array.isArray(result) ? [] : result.usageRecords;
+    const review = buildCandidateReview(
+      installations,
+      registry,
+      excludedLogins,
+      fingerprintKey,
+      new Date().toISOString(),
+      usageRecords
+    );
     showReview(review);
     return `Reviewed ${review.candidates.length} outreach candidate(s) without saving identities.`;
   }

--- a/src/lib/feedback-counter.ts
+++ b/src/lib/feedback-counter.ts
@@ -1,4 +1,11 @@
 import type { Env } from '../types';
+import { installationUsageEnabled } from './installation-usage';
+import {
+  handleInstallationAlarm,
+  handleInstallationDeletion,
+  handleInstallationIncrement,
+  handleInstallationPurge,
+} from './installation-feedback-counter';
 
 const COUNTER_OBJECT_NAME = 'global-feedback-issues-created';
 const COUNTER_STORAGE_KEY = 'total';
@@ -6,6 +13,7 @@ const RECENT_EVENT_IDS_STORAGE_KEY = 'recentEventIds';
 const MAX_RECENT_EVENT_IDS = 1024;
 const MAX_INCREMENT_ATTEMPTS = 3;
 const PUBLIC_BUCKET_SIZE = 100;
+const INSTALLATION_COUNTER_OBJECT_PREFIX = 'installation-feedback:';
 
 type WaitUntilContext = {
   readonly executionCtx: Pick<ExecutionContext, 'waitUntil'>;
@@ -42,6 +50,18 @@ export class FeedbackCounter {
       return Response.json({ total });
     }
 
+    if (request.method === 'POST' && pathname === '/installation/increment') {
+      return handleInstallationIncrement(this.state, this.env, request);
+    }
+
+    if (request.method === 'POST' && pathname === '/installation/delete') {
+      return handleInstallationDeletion(this.state);
+    }
+
+    if (request.method === 'POST' && pathname === '/installation/purge') {
+      return handleInstallationPurge(this.state);
+    }
+
     if (request.method === 'GET' && pathname === '/total') {
       const total =
         (await this.state.storage.get<number>(COUNTER_STORAGE_KEY)) ??
@@ -51,20 +71,42 @@ export class FeedbackCounter {
 
     return new Response('Not found', { status: 404 });
   }
+
+  async alarm(): Promise<void> {
+    await handleInstallationAlarm(this.state, this.env);
+  }
 }
 
 export function scheduleSuccessfulFeedbackCount(
   env: Env,
   repo: string,
-  context?: WaitUntilContext
+  context?: WaitUntilContext,
+  installationId?: number
 ): void {
-  if (!env.FEEDBACK_COUNTER || isExcludedFromFeedbackCount(env, repo)) return;
+  if (!env.FEEDBACK_COUNTER) return;
 
   const eventId = crypto.randomUUID();
-  const task = incrementFeedbackCount(env, eventId).catch(error => {
-    console.error('[BugDrop] Failed to increment anonymous feedback counter:', error);
-    throw error;
-  });
+  const tasks: Promise<void>[] = [];
+  if (!isExcludedFromFeedbackCount(env, repo)) tasks.push(incrementFeedbackCount(env, eventId));
+  if (
+    installationUsageEnabled(env) &&
+    Number.isSafeInteger(installationId) &&
+    (installationId as number) > 0
+  ) {
+    tasks.push(incrementInstallationFeedbackCount(env, installationId as number, eventId));
+  }
+  if (tasks.length === 0) return;
+  const task = Promise.allSettled(tasks)
+    .then(results => {
+      const failure = results.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
+      );
+      if (failure) throw failure.reason;
+    })
+    .catch(error => {
+      console.error('[BugDrop] Failed to record successful feedback count:', error);
+      throw error;
+    });
 
   try {
     if (context) {
@@ -76,6 +118,34 @@ export function scheduleSuccessfulFeedbackCount(
     // Hono unit tests do not provide an ExecutionContext. The task has already
     // started; prevent an unhandled rejection when no runtime can observe it.
     void task.catch(() => undefined);
+  }
+}
+
+export async function deleteInstallationFeedbackCounter(
+  env: Env,
+  installationId: number
+): Promise<void> {
+  if (!env.FEEDBACK_COUNTER) throw new Error('Feedback counter binding is unavailable');
+  const response = await getInstallationCounterStub(env, installationId).fetch(
+    'https://feedback-counter/installation/delete',
+    { method: 'POST' }
+  );
+  if (!response.ok) {
+    throw new Error(`Installation feedback counter deletion failed with ${response.status}`);
+  }
+}
+
+export async function purgeInstallationFeedbackCounter(
+  env: Env,
+  installationId: number
+): Promise<void> {
+  if (!env.FEEDBACK_COUNTER) throw new Error('Feedback counter binding is unavailable');
+  const response = await getInstallationCounterStub(env, installationId).fetch(
+    'https://feedback-counter/installation/purge',
+    { method: 'POST' }
+  );
+  if (!response.ok) {
+    throw new Error(`Installation feedback counter purge failed with ${response.status}`);
   }
 }
 
@@ -119,23 +189,50 @@ export function isExcludedFromFeedbackCount(env: Env, repo: string): boolean {
 }
 
 async function incrementFeedbackCount(env: Env, eventId: string): Promise<void> {
+  const stub = getCounterStub(env);
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventId }),
+  };
+  await sendCounterIncrementWithRetries(
+    () => stub.fetch('https://feedback-counter/increment', init),
+    'Feedback counter increment'
+  );
+}
+
+async function incrementInstallationFeedbackCount(
+  env: Env,
+  installationId: number,
+  eventId: string
+): Promise<void> {
+  const stub = getInstallationCounterStub(env, installationId);
+  const init: RequestInit = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventId, installationId }),
+  };
+  await sendCounterIncrementWithRetries(
+    () => stub.fetch('https://feedback-counter/installation/increment', init),
+    'Installation feedback counter increment'
+  );
+}
+
+async function sendCounterIncrementWithRetries(
+  send: () => Promise<Response>,
+  failureLabel: string
+): Promise<void> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= MAX_INCREMENT_ATTEMPTS; attempt += 1) {
     try {
-      const response = await getCounterStub(env).fetch('https://feedback-counter/increment', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ eventId }),
-      });
-      if (!response.ok) {
-        throw new Error(`Feedback counter increment failed with ${response.status}`);
-      }
+      const response = await send();
+      if (!response.ok) throw new Error(`${failureLabel} failed with ${response.status}`);
       return;
     } catch (error) {
       lastError = error;
     }
   }
-  throw lastError ?? new Error('Feedback counter increment failed');
+  throw lastError ?? new Error(`${failureLabel} failed`);
 }
 
 async function parseEventId(request: Request): Promise<string | null> {
@@ -156,4 +253,15 @@ function getCounterStub(env: Env): DurableObjectStub {
   const namespace = env.FEEDBACK_COUNTER;
   if (!namespace) throw new Error('Feedback counter binding is unavailable');
   return namespace.get(namespace.idFromName(COUNTER_OBJECT_NAME));
+}
+
+function getInstallationCounterStub(env: Env, installationId: number): DurableObjectStub {
+  if (!Number.isSafeInteger(installationId) || installationId <= 0) {
+    throw new Error('Invalid installation ID');
+  }
+  const namespace = env.FEEDBACK_COUNTER;
+  if (!namespace) throw new Error('Feedback counter binding is unavailable');
+  return namespace.get(
+    namespace.idFromName(`${INSTALLATION_COUNTER_OBJECT_PREFIX}${installationId}`)
+  );
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -46,8 +46,15 @@ async function getInstallationId(env: Env, owner: string, repo: string): Promise
     return null;
   }
 
-  const data = (await response.json()) as { id: number };
-  return data.id;
+  const data = (await response.json()) as { id?: unknown };
+  return typeof data.id === 'number' && Number.isSafeInteger(data.id) && data.id > 0
+    ? data.id
+    : null;
+}
+
+export interface InstallationAccess {
+  installationId: number;
+  token: string;
 }
 
 /**
@@ -58,6 +65,17 @@ export async function getInstallationToken(
   owner: string,
   repo: string
 ): Promise<string | null> {
+  return (await getInstallationAccess(env, owner, repo))?.token ?? null;
+}
+
+/**
+ * Get both the installation ID and its repository-scoped access token.
+ */
+export async function getInstallationAccess(
+  env: Env,
+  owner: string,
+  repo: string
+): Promise<InstallationAccess | null> {
   const installationId = await getInstallationId(env, owner, repo);
   if (!installationId) return null;
 
@@ -73,8 +91,10 @@ export async function getInstallationToken(
     return null;
   }
 
-  const data = (await response.json()) as { token: string };
-  return data.token;
+  const data = (await response.json()) as { token?: unknown };
+  return typeof data.token === 'string' && data.token.length > 0
+    ? { installationId, token: data.token }
+    : null;
 }
 
 /**

--- a/src/lib/installation-analytics.ts
+++ b/src/lib/installation-analytics.ts
@@ -1,4 +1,4 @@
-import { installationRecordKey } from './installation-retention';
+export const INSTALLATION_RECORD_PREFIX = 'installation:';
 
 type InstallationAccountType = 'User' | 'Organization';
 
@@ -17,6 +17,13 @@ export interface NewInstallationRecord {
   installationId: number;
   account: InstallationIdentityRecord['account'];
   installedAt: string;
+}
+
+export function installationRecordKey(installationId: number): string {
+  if (!Number.isSafeInteger(installationId) || installationId <= 0) {
+    throw new Error('Invalid installation ID');
+  }
+  return `${INSTALLATION_RECORD_PREFIX}${installationId}`;
 }
 
 export async function createInstallationRecord(

--- a/src/lib/installation-feedback-counter.ts
+++ b/src/lib/installation-feedback-counter.ts
@@ -1,0 +1,170 @@
+import type { Env } from '../types';
+import {
+  deleteInstallationUsageRecord,
+  installationIdentityExists,
+  installationUsageEnabled,
+  installationUsageWasDeleted,
+  writeInstallationUsageRecord,
+} from './installation-usage';
+
+const COUNTER_KEY = 'total';
+const EVENT_IDS_KEY = 'recentEventIds';
+const INSTALLATION_ID_KEY = 'installationId';
+const IDENTITY_CHECKS_REMAINING_KEY = 'identityChecksRemaining';
+const DELETED_UNTIL_KEY = 'deletedUntil';
+const MAX_RECENT_EVENT_IDS = 1024;
+const MIRROR_DELAY_MS = 1_500;
+const IDENTITY_RETRY_MS = 60_000;
+const MAX_IDENTITY_CHECKS = 24 * 60;
+const DELETION_GUARD_MS = 7 * 24 * 60 * 60 * 1_000;
+
+export async function handleInstallationIncrement(
+  state: DurableObjectState,
+  env: Env,
+  request: Request
+): Promise<Response> {
+  const input = await parseIncrement(request);
+  if (!input) return Response.json({ error: 'Invalid increment' }, { status: 400 });
+  const store = env.INSTALLATION_ANALYTICS;
+  if (!installationUsageEnabled(env) || !store) {
+    return Response.json({ error: 'Installation usage is unavailable' }, { status: 503 });
+  }
+
+  return state.blockConcurrencyWhile(async () => {
+    if (await state.storage.get(DELETED_UNTIL_KEY)) {
+      return Response.json({ error: 'Installation is inactive' }, { status: 409 });
+    }
+    if (await installationUsageWasDeleted(store, input.installationId)) {
+      await purgeCounter(state, store, input.installationId);
+      return Response.json({ error: 'Installation is inactive' }, { status: 409 });
+    }
+
+    const total = await state.storage.transaction(async transaction => {
+      const current = (await transaction.get<number>(COUNTER_KEY)) ?? 0;
+      const recentIds = (await transaction.get<string[]>(EVENT_IDS_KEY)) ?? [];
+      if (recentIds.includes(input.eventId)) return current;
+      if (!isNonnegativeInteger(current) || current === Number.MAX_SAFE_INTEGER) {
+        throw new Error('Installation feedback counter is invalid');
+      }
+      const next = current + 1;
+      await transaction.put(COUNTER_KEY, next);
+      await transaction.put(INSTALLATION_ID_KEY, input.installationId);
+      await transaction.put(
+        EVENT_IDS_KEY,
+        [...recentIds, input.eventId].slice(-MAX_RECENT_EVENT_IDS)
+      );
+      return next;
+    });
+    if ((await state.storage.get<number>(IDENTITY_CHECKS_REMAINING_KEY)) === undefined) {
+      await state.storage.put(IDENTITY_CHECKS_REMAINING_KEY, MAX_IDENTITY_CHECKS);
+    }
+    if ((await state.storage.getAlarm()) === null) {
+      await state.storage.setAlarm(Date.now() + MIRROR_DELAY_MS);
+    }
+    return Response.json({ total });
+  });
+}
+
+export async function handleInstallationDeletion(state: DurableObjectState): Promise<Response> {
+  return state.blockConcurrencyWhile(async () => {
+    const deletedUntil = Date.now() + DELETION_GUARD_MS;
+    await state.storage.put(DELETED_UNTIL_KEY, deletedUntil);
+    await state.storage.delete([
+      COUNTER_KEY,
+      EVENT_IDS_KEY,
+      INSTALLATION_ID_KEY,
+      IDENTITY_CHECKS_REMAINING_KEY,
+    ]);
+    await state.storage.setAlarm(deletedUntil);
+    return new Response(null, { status: 204 });
+  });
+}
+
+export async function handleInstallationPurge(state: DurableObjectState): Promise<Response> {
+  return state.blockConcurrencyWhile(async () => {
+    await state.storage.deleteAlarm();
+    await state.storage.deleteAll();
+    return new Response(null, { status: 204 });
+  });
+}
+
+export async function handleInstallationAlarm(state: DurableObjectState, env: Env): Promise<void> {
+  await state.blockConcurrencyWhile(async () => {
+    const deletedUntil = await state.storage.get<number>(DELETED_UNTIL_KEY);
+    if (deletedUntil !== undefined) {
+      if (deletedUntil > Date.now()) await state.storage.setAlarm(deletedUntil);
+      else await state.storage.deleteAll();
+      return;
+    }
+
+    const installationId = await state.storage.get<number>(INSTALLATION_ID_KEY);
+    const total = await state.storage.get<number>(COUNTER_KEY);
+    if (!isPositiveInteger(installationId) || !isNonnegativeInteger(total)) return;
+    try {
+      const store = env.INSTALLATION_ANALYTICS;
+      if (!store) throw new Error('Installation analytics binding is unavailable');
+      if (await installationUsageWasDeleted(store, installationId)) {
+        await purgeCounter(state, store, installationId);
+        return;
+      }
+      if (!(await installationIdentityExists(store, installationId))) {
+        const checksRemaining =
+          (await state.storage.get<number>(IDENTITY_CHECKS_REMAINING_KEY)) ?? MAX_IDENTITY_CHECKS;
+        if (isPositiveInteger(checksRemaining)) {
+          await state.storage.put(IDENTITY_CHECKS_REMAINING_KEY, checksRemaining - 1);
+          await state.storage.setAlarm(Date.now() + IDENTITY_RETRY_MS);
+        } else {
+          await purgeCounter(state, store, installationId);
+        }
+        return;
+      }
+      await writeInstallationUsageRecord(store, installationId, total);
+      await state.storage.delete(IDENTITY_CHECKS_REMAINING_KEY);
+    } catch (error) {
+      await state.storage.setAlarm(Date.now() + MIRROR_DELAY_MS);
+      throw error;
+    }
+  });
+}
+
+async function parseIncrement(
+  request: Request
+): Promise<{ eventId: string; installationId: number } | null> {
+  try {
+    const body = (await request.json()) as { eventId?: unknown; installationId?: unknown };
+    if (
+      typeof body.eventId !== 'string' ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        body.eventId
+      ) ||
+      !isPositiveInteger(body.installationId)
+    ) {
+      return null;
+    }
+    return { eventId: body.eventId, installationId: body.installationId };
+  } catch {
+    return null;
+  }
+}
+
+async function purgeCounter(
+  state: DurableObjectState,
+  store: KVNamespace,
+  installationId: number
+): Promise<void> {
+  await deleteInstallationUsageRecord(store, installationId);
+  await state.storage.delete([
+    COUNTER_KEY,
+    EVENT_IDS_KEY,
+    INSTALLATION_ID_KEY,
+    IDENTITY_CHECKS_REMAINING_KEY,
+  ]);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}

--- a/src/lib/installation-retention.ts
+++ b/src/lib/installation-retention.ts
@@ -1,5 +1,15 @@
 import { generateGitHubAppJWT } from './jwt';
 import { GITHUB_API, githubHeaders } from './github';
+import { INSTALLATION_RECORD_PREFIX, installationRecordKey } from './installation-analytics';
+import {
+  deleteInstallationFeedbackCounter,
+  purgeInstallationFeedbackCounter,
+} from './feedback-counter';
+import {
+  deleteInstallationUsageRecord,
+  installationUsageEnabled,
+  markInstallationUsageDeleted,
+} from './installation-usage';
 import {
   parseInstallationCleanupCheckpoint,
   type InstallationCleanupAudit,
@@ -10,7 +20,6 @@ import type { Env } from '../types';
 
 export type { InstallationCleanupAudit } from './installation-cleanup-state';
 
-const INSTALLATION_RECORD_PREFIX = 'installation:';
 const GITHUB_PAGE_SIZE = 100;
 export const MAX_GITHUB_INSTALLATION_PAGES = 20;
 export const INSTALLATION_SWEEP_PAGE_SIZE = 25;
@@ -30,18 +39,31 @@ interface InstallationSweepOptions {
   confirmInstallationIsInactive?: (env: Env, installationId: number) => Promise<boolean>;
 }
 
-export function installationRecordKey(installationId: number): string {
-  if (!Number.isSafeInteger(installationId) || installationId <= 0) {
-    throw new Error('Invalid installation ID');
-  }
-  return `${INSTALLATION_RECORD_PREFIX}${installationId}`;
-}
+export { installationRecordKey } from './installation-analytics';
 
 export async function deleteInstallationRecord(
   store: KVNamespace,
   installationId: number
 ): Promise<void> {
   await store.delete(installationRecordKey(installationId));
+}
+
+export async function deleteInstallationData(env: Env, installationId: number): Promise<void> {
+  const store = env.INSTALLATION_ANALYTICS;
+  if (!store) throw new Error('INSTALLATION_ANALYTICS binding is required for cleanup');
+
+  if (installationUsageEnabled(env)) {
+    // Tombstone first so a delayed submission cannot recreate usage after uninstall.
+    await markInstallationUsageDeleted(store, installationId);
+    await deleteInstallationFeedbackCounter(env, installationId);
+  } else if (env.FEEDBACK_COUNTER) {
+    await purgeInstallationFeedbackCounter(env, installationId);
+  } else {
+    throw new Error('Feedback counter binding is required for installation cleanup');
+  }
+  await deleteInstallationUsageRecord(store, installationId);
+  // Identity is the retry anchor and is deliberately removed last.
+  await deleteInstallationRecord(store, installationId);
 }
 
 export async function verifyGitHubWebhookSignature(
@@ -143,7 +165,7 @@ export async function sweepInstallationRecords(
     return publishFinalAudit(store, checkpoint.audit);
   }
   if (checkpoint?.phase === 'deleting') {
-    return finishDeletionBatch(store, checkpoint);
+    return finishDeletionBatch(env, checkpoint);
   }
   const listActive = options.listActiveInstallationIds ?? listActiveGitHubInstallationIds;
   const activeIds = await listActive(env);
@@ -200,14 +222,16 @@ export async function sweepInstallationRecords(
     next: nextCheckpoint,
   };
   await store.put(INSTALLATION_CLEANUP_CHECKPOINT_KEY, JSON.stringify(deletingCheckpoint));
-  return finishDeletionBatch(store, deletingCheckpoint);
+  return finishDeletionBatch(env, deletingCheckpoint);
 }
 
 async function finishDeletionBatch(
-  store: KVNamespace,
+  env: Env,
   checkpoint: InstallationDeletingCheckpoint
 ): Promise<InstallationCleanupAudit | null> {
-  await mapInBatches(checkpoint.installationIds, id => deleteInstallationRecord(store, id));
+  const store = env.INSTALLATION_ANALYTICS;
+  if (!store) throw new Error('INSTALLATION_ANALYTICS binding is required for cleanup');
+  await mapInBatches(checkpoint.installationIds, id => deleteInstallationData(env, id));
   return advanceCheckpoint(store, checkpoint.next);
 }
 

--- a/src/lib/installation-usage.ts
+++ b/src/lib/installation-usage.ts
@@ -1,0 +1,102 @@
+import { installationRecordKey } from './installation-analytics';
+import type { Env } from '../types';
+
+const USAGE_PREFIX = 'installation-usage:';
+const DELETION_GUARD_PREFIX = 'installation-usage-deleted:';
+const DELETION_GUARD_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+export interface InstallationUsageRecord {
+  schemaVersion: 1;
+  installationId: number;
+  successfulFeedbackCount: number;
+}
+
+export function installationUsageEnabled(env: Env): boolean {
+  return env.INSTALLATION_USAGE_ENABLED === 'true';
+}
+
+export function installationUsageKey(installationId: number): string {
+  assertInstallationId(installationId);
+  return `${USAGE_PREFIX}${installationId}`;
+}
+
+export function installationUsageDeletionGuardKey(installationId: number): string {
+  assertInstallationId(installationId);
+  return `${DELETION_GUARD_PREFIX}${installationId}`;
+}
+
+export async function installationUsageWasDeleted(
+  store: KVNamespace,
+  installationId: number
+): Promise<boolean> {
+  return (await store.get(installationUsageDeletionGuardKey(installationId))) !== null;
+}
+
+export async function installationIdentityExists(
+  store: KVNamespace,
+  installationId: number
+): Promise<boolean> {
+  return (await store.get(installationRecordKey(installationId))) !== null;
+}
+
+export async function writeInstallationUsageRecord(
+  store: KVNamespace,
+  installationId: number,
+  successfulFeedbackCount: number
+): Promise<void> {
+  const record: InstallationUsageRecord = {
+    schemaVersion: 1,
+    installationId,
+    successfulFeedbackCount,
+  };
+  assertInstallationUsageRecord(record, installationId);
+  await store.put(installationUsageKey(installationId), JSON.stringify(record));
+}
+
+export async function deleteInstallationUsageRecord(
+  store: KVNamespace,
+  installationId: number
+): Promise<void> {
+  await store.delete(installationUsageKey(installationId));
+}
+
+export async function markInstallationUsageDeleted(
+  store: KVNamespace,
+  installationId: number
+): Promise<void> {
+  await store.put(installationUsageDeletionGuardKey(installationId), '1', {
+    expirationTtl: DELETION_GUARD_TTL_SECONDS,
+  });
+}
+
+export function assertInstallationUsageRecord(
+  value: unknown,
+  expectedInstallationId: number
+): asserts value is InstallationUsageRecord {
+  if (
+    !isPlainObject(value) ||
+    !hasExactKeys(value, ['schemaVersion', 'installationId', 'successfulFeedbackCount']) ||
+    value.schemaVersion !== 1 ||
+    value.installationId !== expectedInstallationId ||
+    !Number.isSafeInteger(value.successfulFeedbackCount) ||
+    (value.successfulFeedbackCount as number) < 0
+  ) {
+    throw new Error('Invalid installation usage record');
+  }
+}
+
+function assertInstallationId(value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error('Invalid installation ID');
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value).sort();
+  return (
+    actual.length === expected.length &&
+    [...expected].sort().every((key, index) => actual[index] === key)
+  );
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/lib/installation-usage.ts
+++ b/src/lib/installation-usage.ts
@@ -5,7 +5,7 @@ const USAGE_PREFIX = 'installation-usage:';
 const DELETION_GUARD_PREFIX = 'installation-usage-deleted:';
 const DELETION_GUARD_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-export interface InstallationUsageRecord {
+interface InstallationUsageRecord {
   schemaVersion: 1;
   installationId: number;
   successfulFeedbackCount: number;
@@ -15,12 +15,12 @@ export function installationUsageEnabled(env: Env): boolean {
   return env.INSTALLATION_USAGE_ENABLED === 'true';
 }
 
-export function installationUsageKey(installationId: number): string {
+function installationUsageKey(installationId: number): string {
   assertInstallationId(installationId);
   return `${USAGE_PREFIX}${installationId}`;
 }
 
-export function installationUsageDeletionGuardKey(installationId: number): string {
+function installationUsageDeletionGuardKey(installationId: number): string {
   assertInstallationId(installationId);
   return `${DELETION_GUARD_PREFIX}${installationId}`;
 }
@@ -69,7 +69,7 @@ export async function markInstallationUsageDeleted(
   });
 }
 
-export function assertInstallationUsageRecord(
+function assertInstallationUsageRecord(
   value: unknown,
   expectedInstallationId: number
 ): asserts value is InstallationUsageRecord {

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -10,6 +10,7 @@ import type {
 import { redactConsoleLogMessage } from '../widget/console-log-redaction';
 import {
   getInstallationToken,
+  getInstallationAccess,
   createIssue,
   uploadScreenshotAsAsset,
   uploadAttachmentAsAsset,
@@ -281,8 +282,8 @@ api.post('/feedback', async c => {
 
   try {
     // Get installation token
-    const token = await getInstallationToken(c.env, owner, repo);
-    if (!token) {
+    const access = await getInstallationAccess(c.env, owner, repo);
+    if (!access) {
       const appName = c.env.GITHUB_APP_NAME || 'your-app-name';
       return c.json(
         {
@@ -292,6 +293,7 @@ api.post('/feedback', async c => {
         403
       );
     }
+    const { token, installationId } = access;
 
     // Upload screenshot as file and get URL
     let screenshotUrl: string | undefined;
@@ -370,7 +372,7 @@ api.post('/feedback', async c => {
       throw new Error('GitHub returned an invalid Issue result');
     }
 
-    scheduleSuccessfulFeedbackCount(c.env, payload.repo, c);
+    scheduleSuccessfulFeedbackCount(c.env, payload.repo, c, installationId);
 
     return c.json({
       success: true,

--- a/src/routes/github-webhook.ts
+++ b/src/routes/github-webhook.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import type { Env } from '../types';
 import {
   confirmGitHubInstallationIsInactive,
-  deleteInstallationRecord,
+  deleteInstallationData,
   verifyGitHubWebhookSignature,
 } from '../lib/installation-retention';
 import {
@@ -65,13 +65,13 @@ export function createGitHubWebhook(dependencies: GitHubWebhookDependencies = {}
       }
       await createInstallationRecord(store, payload.installation);
       if (await confirmInstallationIsInactive(c.env, payload.installation.installationId)) {
-        await deleteInstallationRecord(store, payload.installation.installationId);
+        await deleteInstallationData(c.env, payload.installation.installationId);
         return c.json({ accepted: true }, 202);
       }
       return c.json({ created: true }, 201);
     }
 
-    await deleteInstallationRecord(store, payload.installation.installationId);
+    await deleteInstallationData(c.env, payload.installation.installationId);
     return c.json({ deleted: true }, 200);
   });
 

--- a/src/routes/structured-feedback.ts
+++ b/src/routes/structured-feedback.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Keep the isolated structured contract out of the legacy route. */
 import type { Context } from 'hono';
-import { GitHubLabelError, createIssue, getInstallationToken, isRepoPublic } from '../lib/github';
+import { GitHubLabelError, createIssue, getInstallationAccess, isRepoPublic } from '../lib/github';
 import {
   escapeMarkdownLiteral,
   formatMarkdownCodeSpan,
@@ -93,8 +93,8 @@ export async function handleStructuredFeedback(c: StructuredContext, input: unkn
   const [owner, repo] = payload.repo.split('/');
 
   try {
-    const token = await getInstallationToken(c.env, owner, repo);
-    if (!token) {
+    const access = await getInstallationAccess(c.env, owner, repo);
+    if (!access) {
       const appName = c.env.GITHUB_APP_NAME || 'your-app-name';
       return c.json(
         {
@@ -104,6 +104,7 @@ export async function handleStructuredFeedback(c: StructuredContext, input: unkn
         403
       );
     }
+    const { token, installationId } = access;
 
     const labelResolution = resolveVariantLabels(
       c.env.VARIANT_LABELS,
@@ -150,7 +151,7 @@ export async function handleStructuredFeedback(c: StructuredContext, input: unkn
       throw new Error('GitHub returned an invalid Issue result');
     }
 
-    scheduleSuccessfulFeedbackCount(c.env, payload.repo, c);
+    scheduleSuccessfulFeedbackCount(c.env, payload.repo, c, installationId);
 
     return c.json({
       success: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface Env {
   BUGDROP_BOARD_TOKEN_ISSUER?: string; // Optional override for board token issuer
   FEEDBACK_COUNT_BASELINE?: string; // Anonymous external-Issue count before live counting
   FEEDBACK_COUNT_EXCLUDED_OWNERS?: string; // Comma-separated first-party/test owners
+  INSTALLATION_USAGE_ENABLED?: string; // Exact "true" enables private per-install successful-Issue counts
 
   // Bindings
   ASSETS: Fetcher;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -22,6 +22,10 @@ class TestGitHubLabelError extends Error {
 
 vi.mock('../src/lib/github', () => ({
   getInstallationToken: (...args: unknown[]) => mockGetInstallationToken(...args),
+  getInstallationAccess: async (...args: unknown[]) => {
+    const token = await mockGetInstallationToken(...args);
+    return token ? { token, installationId: 123456 } : null;
+  },
   createIssue: (...args: unknown[]) => mockCreateIssue(...args),
   uploadScreenshotAsAsset: (...args: unknown[]) => mockUploadScreenshotAsAsset(...args),
   uploadAttachmentAsAsset: (...args: unknown[]) => mockUploadAttachmentAsAsset(...args),

--- a/test/feedbackCounter.test.ts
+++ b/test/feedbackCounter.test.ts
@@ -22,8 +22,7 @@ const baseEnv: Env = {
 describe('anonymous feedback counter', () => {
   it('initializes from the audited baseline and stores no identifying values', async () => {
     const values = new Map<string, unknown>();
-    const storage = createStorage(values);
-    const counter = new FeedbackCounter({ storage } as unknown as DurableObjectState, {
+    const counter = new FeedbackCounter(createState(values), {
       ...baseEnv,
       FEEDBACK_COUNT_BASELINE: '3116',
     });
@@ -42,10 +41,10 @@ describe('anonymous feedback counter', () => {
 
   it('deduplicates an ambiguous retry using the same opaque event ID', async () => {
     const values = new Map<string, unknown>();
-    const counter = new FeedbackCounter(
-      { storage: createStorage(values) } as unknown as DurableObjectState,
-      { ...baseEnv, FEEDBACK_COUNT_BASELINE: '3116' }
-    );
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      FEEDBACK_COUNT_BASELINE: '3116',
+    });
     const eventId = '11111111-1111-4111-8111-111111111111';
 
     const first = await counter.fetch(incrementRequest(eventId));
@@ -99,7 +98,7 @@ describe('anonymous feedback counter', () => {
     await expect(queued).rejects.toThrow('counter unavailable');
     expect(fetch).toHaveBeenCalledTimes(3);
     expect(error).toHaveBeenCalledWith(
-      '[BugDrop] Failed to increment anonymous feedback counter:',
+      '[BugDrop] Failed to record successful feedback count:',
       expect.any(Error)
     );
     error.mockRestore();
@@ -124,6 +123,50 @@ describe('anonymous feedback counter', () => {
     expect(firstBody).toBe(retryBody);
   });
 
+  it('keeps waitUntil pending until both independent counter deliveries settle', async () => {
+    const globalFetch = vi.fn().mockRejectedValue(new Error('global unavailable'));
+    let finishInstallation: (response: Response) => void = () => undefined;
+    const installationFetch = vi.fn(
+      () =>
+        new Promise<Response>(resolve => {
+          finishInstallation = resolve;
+        })
+    );
+    const namespace = {
+      idFromName: vi.fn((name: string) => name as unknown as DurableObjectId),
+      get: vi.fn((id: DurableObjectId) => ({
+        fetch: String(id).startsWith('installation-feedback:') ? installationFetch : globalFetch,
+      })),
+    } as unknown as DurableObjectNamespace;
+    const waitUntil = vi.fn();
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    scheduleSuccessfulFeedbackCount(
+      {
+        ...baseEnv,
+        FEEDBACK_COUNTER: namespace,
+        INSTALLATION_USAGE_ENABLED: 'true',
+      },
+      'external/app',
+      { executionCtx: { waitUntil } },
+      42
+    );
+    const queued = waitUntil.mock.calls[0][0] as Promise<void>;
+    let settled = false;
+    void queued
+      .finally(() => {
+        settled = true;
+      })
+      .catch(() => undefined);
+    await vi.waitFor(() => expect(globalFetch).toHaveBeenCalledTimes(3));
+    expect(settled).toBe(false);
+
+    finishInstallation(Response.json({ total: 1 }));
+    await expect(queued).rejects.toThrow('global unavailable');
+    expect(installationFetch).toHaveBeenCalledOnce();
+    error.mockRestore();
+  });
+
   it('does not schedule counter work for excluded owners', () => {
     const fetch = vi.fn();
     const waitUntil = vi.fn();
@@ -139,6 +182,371 @@ describe('anonymous feedback counter', () => {
 
     expect(fetch).not.toHaveBeenCalled();
     expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it('stores an exact private count for one active installation without repository data', async () => {
+    const values = new Map<string, unknown>();
+    const kvValues = new Map<string, string>([['installation:42', '{"active":true}']]);
+    const store = createKv(kvValues);
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: store,
+    });
+
+    const request = installationIncrementRequest(42, '11111111-1111-4111-8111-111111111111');
+    expect(await (await counter.fetch(request)).json()).toEqual({ total: 1 });
+    await counter.alarm();
+
+    expect(JSON.parse(kvValues.get('installation-usage:42') ?? '')).toEqual({
+      schemaVersion: 1,
+      installationId: 42,
+      successfulFeedbackCount: 1,
+    });
+    expect(JSON.stringify([...values.values(), ...kvValues.values()])).not.toContain(
+      'external/app'
+    );
+  });
+
+  it('does not lose a valid first count while the installation identity is still propagating', async () => {
+    const values = new Map<string, unknown>();
+    const kvValues = new Map<string, string>();
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: createKv(kvValues),
+    });
+
+    const response = await counter.fetch(
+      installationIncrementRequest(42, '11111111-1111-4111-8111-111111111111')
+    );
+    await counter.alarm();
+
+    expect(response.status).toBe(200);
+    expect(values.get('total')).toBe(1);
+    expect(kvValues.has('installation-usage:42')).toBe(false);
+
+    kvValues.set('installation:42', '{"active":true}');
+    await counter.alarm();
+    expect(JSON.parse(kvValues.get('installation-usage:42') ?? '')).toMatchObject({
+      successfulFeedbackCount: 1,
+    });
+  });
+
+  it('purges an unanchored count if no installation identity arrives within a day', async () => {
+    const values = new Map<string, unknown>([
+      ['total', 1],
+      ['installationId', 42],
+      ['identityChecksRemaining', 0],
+    ]);
+    const kvValues = new Map<string, string>();
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: createKv(kvValues),
+    });
+
+    await counter.alarm();
+
+    expect(values.size).toBe(0);
+    expect(kvValues.has('installation-usage:42')).toBe(false);
+  });
+
+  it('keeps the durable purge anchor until a failed KV deletion can retry', async () => {
+    const values = new Map<string, unknown>([
+      ['total', 1],
+      ['installationId', 42],
+      ['identityChecksRemaining', 0],
+    ]);
+    const kvValues = new Map<string, string>([
+      ['installation-usage:42', '{"successfulFeedbackCount":1}'],
+    ]);
+    const store = createKv(kvValues);
+    vi.mocked(store.delete).mockRejectedValueOnce(new Error('KV unavailable'));
+    const state = createState(values);
+    const counter = new FeedbackCounter(state, {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: store,
+    });
+
+    await expect(counter.alarm()).rejects.toThrow('KV unavailable');
+    expect(values.get('installationId')).toBe(42);
+    expect(await state.storage.getAlarm()).not.toBeNull();
+
+    await counter.alarm();
+    expect(values.size).toBe(0);
+    expect(kvValues.has('installation-usage:42')).toBe(false);
+  });
+
+  it('retries tombstone cleanup without dropping its durable purge anchor', async () => {
+    const values = new Map<string, unknown>([
+      ['total', 7],
+      ['installationId', 42],
+      ['identityChecksRemaining', 1],
+    ]);
+    const kvValues = new Map<string, string>([
+      ['installation-usage:42', '{"successfulFeedbackCount":7}'],
+      ['installation-usage-deleted:42', '1'],
+    ]);
+    const store = createKv(kvValues);
+    vi.mocked(store.delete).mockRejectedValueOnce(new Error('KV unavailable'));
+    const state = createState(values);
+    const counter = new FeedbackCounter(state, {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: store,
+    });
+
+    await expect(counter.alarm()).rejects.toThrow('KV unavailable');
+    expect(values.get('installationId')).toBe(42);
+    expect(values.get('total')).toBe(7);
+    expect(await state.storage.getAlarm()).not.toBeNull();
+
+    await counter.alarm();
+    expect(values.size).toBe(0);
+    expect(kvValues.has('installation-usage:42')).toBe(false);
+  });
+
+  it('re-arms the alarm after a transient KV read failure', async () => {
+    const values = new Map<string, unknown>([
+      ['total', 1],
+      ['installationId', 42],
+      ['identityChecksRemaining', 1],
+    ]);
+    const store = createKv(new Map());
+    vi.mocked(store.get).mockRejectedValueOnce(new Error('KV unavailable'));
+    const state = createState(values);
+    const counter = new FeedbackCounter(state, {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: store,
+    });
+
+    await expect(counter.alarm()).rejects.toThrow('KV unavailable');
+    expect(values.get('installationId')).toBe(42);
+    expect(await state.storage.getAlarm()).not.toBeNull();
+  });
+
+  it('does not reset the identity retry budget when more feedback arrives', async () => {
+    const values = new Map<string, unknown>();
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: createKv(new Map()),
+    });
+
+    await counter.fetch(installationIncrementRequest(42, '11111111-1111-4111-8111-111111111111'));
+    const originalBudget = values.get('identityChecksRemaining');
+    await counter.alarm();
+    const reducedBudget = values.get('identityChecksRemaining');
+    await counter.fetch(installationIncrementRequest(42, '22222222-2222-4222-8222-222222222222'));
+
+    expect(originalBudget).toBe(1440);
+    expect(reducedBudget).toBe(1439);
+    expect(values.get('identityChecksRemaining')).toBe(reducedBudget);
+    expect(values.get('total')).toBe(2);
+    expect([...values.keys()]).not.toContain('identityDeadline');
+    expect(
+      [...values.values()]
+        .filter((value): value is number => typeof value === 'number')
+        .every(value => value < 1_000_000_000)
+    ).toBe(true);
+  });
+
+  it('keeps a pending mirror retryable when installation analytics is unavailable', async () => {
+    const values = new Map<string, unknown>([
+      ['total', 1],
+      ['installationId', 42],
+      ['identityChecksRemaining', 1],
+    ]);
+    const state = createState(values);
+    const counter = new FeedbackCounter(state, {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+    });
+
+    await expect(counter.alarm()).rejects.toThrow('analytics binding is unavailable');
+
+    expect(values.get('total')).toBe(1);
+    expect(await state.storage.getAlarm()).not.toBeNull();
+  });
+
+  it('deduplicates per-install retries and repairs a missing KV mirror', async () => {
+    const values = new Map<string, unknown>();
+    const kvValues = new Map<string, string>([['installation:42', '{"active":true}']]);
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: createKv(kvValues),
+    });
+    const eventId = '11111111-1111-4111-8111-111111111111';
+
+    await counter.fetch(installationIncrementRequest(42, eventId));
+    await counter.alarm();
+    kvValues.delete('installation-usage:42');
+    await counter.fetch(installationIncrementRequest(42, eventId));
+    await counter.alarm();
+
+    expect(values.get('total')).toBe(1);
+    expect(JSON.parse(kvValues.get('installation-usage:42') ?? '')).toMatchObject({
+      successfulFeedbackCount: 1,
+    });
+  });
+
+  it('refuses and purges delayed increments after an uninstall tombstone', async () => {
+    const values = new Map<string, unknown>([['total', 7]]);
+    const kvValues = new Map<string, string>([
+      ['installation:42', '{"active":true}'],
+      ['installation-usage:42', '{"successfulFeedbackCount":7}'],
+      ['installation-usage-deleted:42', '1'],
+    ]);
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: createKv(kvValues),
+    });
+
+    const response = await counter.fetch(
+      installationIncrementRequest(42, '11111111-1111-4111-8111-111111111111')
+    );
+
+    expect(response.status).toBe(409);
+    expect(values.size).toBe(0);
+    expect(kvValues.has('installation-usage:42')).toBe(false);
+  });
+
+  it('keeps a strongly consistent deletion marker when KV still looks active', async () => {
+    const values = new Map<string, unknown>();
+    const kvValues = new Map<string, string>([['installation:42', '{"active":true}']]);
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: createKv(kvValues),
+    });
+
+    expect(
+      (
+        await counter.fetch(
+          new Request('https://feedback-counter/installation/delete', { method: 'POST' })
+        )
+      ).status
+    ).toBe(204);
+    const response = await counter.fetch(
+      installationIncrementRequest(42, '11111111-1111-4111-8111-111111111111')
+    );
+
+    expect(response.status).toBe(409);
+    expect(values.get('total')).toBeUndefined();
+    expect(kvValues.has('installation-usage:42')).toBe(false);
+  });
+
+  it('hard-purges without retaining a deletion marker while collection is disabled', async () => {
+    const values = new Map<string, unknown>([
+      ['total', 7],
+      ['installationId', 42],
+    ]);
+    const state = createState(values);
+    const counter = new FeedbackCounter(state, baseEnv);
+
+    const response = await counter.fetch(
+      new Request('https://feedback-counter/installation/purge', { method: 'POST' })
+    );
+
+    expect(response.status).toBe(204);
+    expect(values.size).toBe(0);
+    expect(await state.storage.getAlarm()).toBeNull();
+  });
+
+  it('coalesces concurrent increments into one exact KV mirror write', async () => {
+    const values = new Map<string, unknown>();
+    const kvValues = new Map<string, string>([['installation:42', '{"active":true}']]);
+    const store = createKv(kvValues);
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: store,
+    });
+
+    await Promise.all([
+      counter.fetch(installationIncrementRequest(42, '11111111-1111-4111-8111-111111111111')),
+      counter.fetch(installationIncrementRequest(42, '22222222-2222-4222-8222-222222222222')),
+    ]);
+    expect(kvValues.has('installation-usage:42')).toBe(false);
+    await counter.alarm();
+
+    expect(JSON.parse(kvValues.get('installation-usage:42') ?? '')).toMatchObject({
+      successfulFeedbackCount: 2,
+    });
+    expect(store.put).toHaveBeenCalledOnce();
+  });
+
+  it('retries a failed asynchronous mirror without incrementing again', async () => {
+    const values = new Map<string, unknown>();
+    const kvValues = new Map<string, string>([['installation:42', '{"active":true}']]);
+    const store = createKv(kvValues);
+    vi.mocked(store.put).mockRejectedValueOnce(new Error('KV rate limited'));
+    const counter = new FeedbackCounter(createState(values), {
+      ...baseEnv,
+      INSTALLATION_USAGE_ENABLED: 'true',
+      INSTALLATION_ANALYTICS: store,
+    });
+
+    await counter.fetch(installationIncrementRequest(42, '11111111-1111-4111-8111-111111111111'));
+    await expect(counter.alarm()).rejects.toThrow('KV rate limited');
+    await counter.alarm();
+
+    expect(values.get('total')).toBe(1);
+    expect(JSON.parse(kvValues.get('installation-usage:42') ?? '')).toMatchObject({
+      successfulFeedbackCount: 1,
+    });
+    expect(store.put).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps per-install counting off unless the gate is exactly true', async () => {
+    const fetch = vi.fn();
+    const waitUntil = vi.fn();
+    const env = {
+      ...baseEnv,
+      FEEDBACK_COUNTER: createNamespace(fetch),
+      FEEDBACK_COUNT_EXCLUDED_OWNERS: 'mean-weasel',
+    };
+
+    scheduleSuccessfulFeedbackCount(
+      env,
+      'mean-weasel/bugdrop',
+      { executionCtx: { waitUntil } },
+      42
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(waitUntil).not.toHaveBeenCalled();
+  });
+
+  it('targets the installation-specific object and carries no repository identity', async () => {
+    const fetch = vi.fn().mockResolvedValue(Response.json({ total: 1 }));
+    const namespace = createNamespace(fetch);
+    const waitUntil = vi.fn();
+    const env = {
+      ...baseEnv,
+      FEEDBACK_COUNTER: namespace,
+      FEEDBACK_COUNT_EXCLUDED_OWNERS: 'mean-weasel',
+      INSTALLATION_USAGE_ENABLED: 'true',
+    };
+
+    scheduleSuccessfulFeedbackCount(
+      env,
+      'mean-weasel/private-repo',
+      { executionCtx: { waitUntil } },
+      42
+    );
+    await (waitUntil.mock.calls[0][0] as Promise<void>);
+
+    expect(namespace.idFromName).toHaveBeenCalledExactlyOnceWith('installation-feedback:42');
+    const body = String((fetch.mock.calls[0][1] as RequestInit).body);
+    expect(JSON.parse(body)).toMatchObject({ installationId: 42 });
+    expect(body).not.toContain('mean-weasel');
+    expect(body).not.toContain('private-repo');
   });
 
   it.each([
@@ -160,6 +568,14 @@ function incrementRequest(eventId: string): Request {
   });
 }
 
+function installationIncrementRequest(installationId: number, eventId: string): Request {
+  return new Request('https://feedback-counter/installation/increment', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ eventId, installationId }),
+  });
+}
+
 function createNamespace(fetch: ReturnType<typeof vi.fn>): DurableObjectNamespace {
   const id = {} as DurableObjectId;
   return {
@@ -169,8 +585,25 @@ function createNamespace(fetch: ReturnType<typeof vi.fn>): DurableObjectNamespac
 }
 
 function createStorage(values: Map<string, unknown>): DurableObjectStorage {
+  let alarm: number | null = null;
   return {
     get: async <T>(key: string) => values.get(key) as T | undefined,
+    put: async <T>(key: string, value: T) => {
+      values.set(key, value);
+    },
+    delete: async (keyOrKeys: string | string[]) => {
+      const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
+      const deleted = keys.filter(key => values.delete(key)).length;
+      return Array.isArray(keyOrKeys) ? deleted : deleted > 0;
+    },
+    deleteAll: async () => values.clear(),
+    getAlarm: async () => alarm,
+    setAlarm: async (value: number | Date) => {
+      alarm = value instanceof Date ? value.getTime() : value;
+    },
+    deleteAlarm: async () => {
+      alarm = null;
+    },
     transaction: async <T>(
       closure: (transaction: DurableObjectTransaction) => Promise<T>
     ): Promise<T> =>
@@ -181,4 +614,32 @@ function createStorage(values: Map<string, unknown>): DurableObjectStorage {
         },
       } as DurableObjectTransaction),
   } as DurableObjectStorage;
+}
+
+function createState(values: Map<string, unknown>): DurableObjectState {
+  const storage = createStorage(values);
+  let tail = Promise.resolve();
+  return {
+    storage,
+    blockConcurrencyWhile: <T>(callback: () => Promise<T>): Promise<T> => {
+      const result = tail.then(callback, callback);
+      tail = result.then(
+        () => undefined,
+        () => undefined
+      );
+      return result;
+    },
+  } as unknown as DurableObjectState;
+}
+
+function createKv(values: Map<string, string>): KVNamespace {
+  return {
+    get: vi.fn(async (key: string) => values.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      values.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      values.delete(key);
+    }),
+  } as unknown as KVNamespace;
 }

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -10,6 +10,7 @@ vi.mock('../src/lib/jwt', () => ({ generateGitHubAppJWT: mockGenerateGitHubAppJW
 import {
   GitHubLabelError,
   createIssue,
+  getInstallationAccess,
   getInstallationToken,
   isRepoPublic,
   uploadAttachmentAsAsset,
@@ -135,6 +136,39 @@ describe('GitHub API boundary', () => {
     ]);
     await expect(getInstallationToken(env, 'acme', 'widgets')).resolves.toBeNull();
     await expect(getInstallationToken({} as Env, 'acme', 'widgets')).resolves.toBeNull();
+  });
+
+  it('returns the validated installation ID with its access token', async () => {
+    const env = { GITHUB_APP_ID: '42', GITHUB_PRIVATE_KEY: 'private-key' } as Env;
+    expectRequests([
+      {
+        url: `${API_ROOT}/installation`,
+        token: JWT,
+        response: Response.json({ id: 123 }),
+      },
+      {
+        url: 'https://api.github.com/app/installations/123/access_tokens',
+        method: 'POST',
+        token: JWT,
+        response: Response.json({ token: TOKEN }),
+      },
+    ]);
+
+    await expect(getInstallationAccess(env, 'acme', 'widgets')).resolves.toEqual({
+      installationId: 123,
+      token: TOKEN,
+    });
+
+    for (const id of [0, -1, 1.5, '123', null]) {
+      expectRequests([
+        {
+          url: `${API_ROOT}/installation`,
+          token: JWT,
+          response: Response.json({ id }),
+        },
+      ]);
+      await expect(getInstallationAccess(env, 'acme', 'widgets')).resolves.toBeNull();
+    }
   });
 
   it('creates issues and classifies only structured label validation failures', async () => {

--- a/test/installationCleanupDurability.test.ts
+++ b/test/installationCleanupDurability.test.ts
@@ -9,6 +9,12 @@ import {
 const baseEnv = {
   GITHUB_APP_ID: '123',
   GITHUB_PRIVATE_KEY: 'test-private-key',
+  FEEDBACK_COUNTER: {
+    idFromName: vi.fn().mockReturnValue({} as DurableObjectId),
+    get: vi.fn().mockReturnValue({
+      fetch: vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+    }),
+  } as unknown as DurableObjectNamespace,
 } as Env;
 
 function createStore(overrides: Partial<KVNamespace> = {}): KVNamespace {
@@ -73,7 +79,8 @@ describe('installation cleanup durability', () => {
         createOptions()
       )
     ).rejects.toThrow('KV deletion failed');
-    expect(deletionFailureStore.put).toHaveBeenCalledExactlyOnceWith(
+    expect(deletionFailureStore.put).toHaveBeenNthCalledWith(
+      1,
       INSTALLATION_CLEANUP_CHECKPOINT_KEY,
       expect.stringContaining('"phase":"deleting"')
     );
@@ -102,6 +109,7 @@ describe('installation cleanup durability', () => {
       put: vi
         .fn()
         .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
         .mockRejectedValueOnce(new Error('checkpoint unavailable'))
         .mockResolvedValue(undefined),
     });
@@ -117,15 +125,17 @@ describe('installation cleanup durability', () => {
     expect(result).toEqual(audit);
     expect(options.listActiveInstallationIds).toHaveBeenCalledTimes(1);
     expect(store.list).toHaveBeenCalledTimes(1);
-    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation:3');
+    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation-usage:3');
     expect(store.delete).toHaveBeenNthCalledWith(2, 'installation:3');
+    expect(store.delete).toHaveBeenNthCalledWith(3, 'installation-usage:3');
+    expect(store.delete).toHaveBeenNthCalledWith(4, 'installation:3');
     expect(store.put).toHaveBeenNthCalledWith(
-      3,
+      4,
       INSTALLATION_CLEANUP_CHECKPOINT_KEY,
       JSON.stringify(finalizing)
     );
     expect(store.put).toHaveBeenNthCalledWith(
-      4,
+      5,
       INSTALLATION_CLEANUP_AUDIT_KEY,
       JSON.stringify(audit)
     );

--- a/test/installationCleanupScale.test.ts
+++ b/test/installationCleanupScale.test.ts
@@ -22,6 +22,12 @@ const baseEnv: Env = {
   GITHUB_APP_NAME: 'test-bugdrop-app',
   MAX_SCREENSHOT_SIZE_MB: '5',
   ASSETS: {} as Fetcher,
+  FEEDBACK_COUNTER: {
+    idFromName: vi.fn().mockReturnValue({} as DurableObjectId),
+    get: vi.fn().mockReturnValue({
+      fetch: vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+    }),
+  } as unknown as DurableObjectNamespace,
 };
 
 function createStore(overrides: Partial<KVNamespace> = {}): KVNamespace {
@@ -124,7 +130,7 @@ describe('installation cleanup boundaries', () => {
     );
 
     expect(result).toBeNull();
-    expect(store.delete).toHaveBeenCalledTimes(INSTALLATION_SWEEP_PAGE_SIZE);
+    expect(store.delete).toHaveBeenCalledTimes(INSTALLATION_SWEEP_PAGE_SIZE * 2);
     expect(confirmInstallationIsInactive).toHaveBeenCalledTimes(INSTALLATION_SWEEP_PAGE_SIZE);
     expect(peakConfirmations).toBe(MAX_CONCURRENT_CLEANUP_OPERATIONS);
     expect(MAX_GITHUB_INSTALLATION_PAGES + INSTALLATION_SWEEP_PAGE_SIZE).toBeLessThanOrEqual(50);
@@ -229,6 +235,7 @@ describe('installation cleanup boundaries', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(store.delete).toHaveBeenCalledExactlyOnceWith('installation:42');
+    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation-usage:42');
+    expect(store.delete).toHaveBeenNthCalledWith(2, 'installation:42');
   });
 });

--- a/test/installationRetention.test.ts
+++ b/test/installationRetention.test.ts
@@ -3,6 +3,7 @@ import type { Env } from '../src/types';
 import {
   INSTALLATION_CLEANUP_AUDIT_KEY,
   INSTALLATION_CLEANUP_CHECKPOINT_KEY,
+  deleteInstallationData,
   listActiveGitHubInstallationIds,
   sweepInstallationRecords,
   verifyGitHubWebhookSignature,
@@ -13,6 +14,15 @@ const githubWebhook = createGitHubWebhook({
   confirmInstallationIsInactive: vi.fn().mockResolvedValue(false),
 });
 
+function createCounterNamespace(
+  fetch = vi.fn().mockResolvedValue(new Response(null, { status: 204 }))
+): DurableObjectNamespace {
+  return {
+    idFromName: vi.fn().mockReturnValue({} as DurableObjectId),
+    get: vi.fn().mockReturnValue({ fetch }),
+  } as unknown as DurableObjectNamespace;
+}
+
 const baseEnv: Env = {
   GITHUB_APP_ID: '123',
   GITHUB_PRIVATE_KEY: 'test-private-key',
@@ -22,6 +32,7 @@ const baseEnv: Env = {
   GITHUB_APP_NAME: 'test-bugdrop-app',
   MAX_SCREENSHOT_SIZE_MB: '5',
   ASSETS: {} as Fetcher,
+  FEEDBACK_COUNTER: createCounterNamespace(),
 };
 
 function createStore(overrides: Partial<KVNamespace> = {}): KVNamespace {
@@ -67,6 +78,99 @@ describe('installation retention safeguards', () => {
     ).resolves.toBe(false);
   });
 
+  it('deletes usage before identity so partial cleanup remains retryable', async () => {
+    const operations: string[] = [];
+    const store = createStore({
+      put: vi.fn(async (key: string) => {
+        operations.push(`put:${key}`);
+      }),
+      delete: vi.fn(async (key: string) => {
+        operations.push(`delete:${key}`);
+      }),
+    });
+    const namespace = {
+      idFromName: vi.fn().mockReturnValue({} as DurableObjectId),
+      get: vi.fn().mockReturnValue({
+        fetch: vi.fn(async () => {
+          operations.push('delete:durable-counter');
+          return new Response(null, { status: 204 });
+        }),
+      }),
+    } as unknown as DurableObjectNamespace;
+
+    await deleteInstallationData(
+      {
+        ...baseEnv,
+        INSTALLATION_ANALYTICS: store,
+        FEEDBACK_COUNTER: namespace,
+        INSTALLATION_USAGE_ENABLED: 'true',
+      },
+      42
+    );
+
+    expect(operations).toEqual([
+      'put:installation-usage-deleted:42',
+      'delete:durable-counter',
+      'delete:installation-usage:42',
+      'delete:installation:42',
+    ]);
+  });
+
+  it('purges old usage without creating guards while collection is disabled', async () => {
+    const operations: string[] = [];
+    const store = createStore({
+      put: vi.fn(async (key: string) => {
+        operations.push(`put:${key}`);
+      }),
+      delete: vi.fn(async (key: string) => {
+        operations.push(`delete:${key}`);
+      }),
+    });
+    const fetch = vi.fn(async (request: RequestInfo | URL) => {
+      operations.push(`counter:${String(request)}`);
+      return new Response(null, { status: 204 });
+    });
+
+    await deleteInstallationData(
+      {
+        ...baseEnv,
+        INSTALLATION_ANALYTICS: store,
+        FEEDBACK_COUNTER: createCounterNamespace(fetch),
+      },
+      42
+    );
+
+    expect(operations).toEqual([
+      'counter:https://feedback-counter/installation/purge',
+      'delete:installation-usage:42',
+      'delete:installation:42',
+    ]);
+  });
+
+  it('keeps the installation identity when counter cleanup fails', async () => {
+    const store = createStore();
+    const namespace = {
+      idFromName: vi.fn().mockReturnValue({} as DurableObjectId),
+      get: vi.fn().mockReturnValue({
+        fetch: vi.fn().mockResolvedValue(new Response(null, { status: 500 })),
+      }),
+    } as unknown as DurableObjectNamespace;
+
+    await expect(
+      deleteInstallationData(
+        {
+          ...baseEnv,
+          INSTALLATION_ANALYTICS: store,
+          FEEDBACK_COUNTER: namespace,
+          INSTALLATION_USAGE_ENABLED: 'true',
+        },
+        42
+      )
+    ).rejects.toThrow('deletion failed');
+
+    expect(store.delete).not.toHaveBeenCalledWith('installation:42');
+  });
+
   it('deletes only the uninstalled app record after authenticating the webhook', async () => {
     const store = createStore();
     const body = JSON.stringify({ action: 'deleted', installation: { id: 987654 } });
@@ -84,8 +188,30 @@ describe('installation retention safeguards', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(store.delete).toHaveBeenCalledExactlyOnceWith('installation:987654');
-    expect(store.put).not.toHaveBeenCalled();
+    expect(store.put).not.toHaveBeenCalledWith(
+      'installation-usage-deleted:987654',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation-usage:987654');
+    expect(store.delete).toHaveBeenNthCalledWith(2, 'installation:987654');
+  });
+
+  it('keeps the identity whenever its durable counter binding is unavailable', async () => {
+    const store = createStore();
+
+    await expect(
+      deleteInstallationData(
+        {
+          ...baseEnv,
+          INSTALLATION_ANALYTICS: store,
+          FEEDBACK_COUNTER: undefined,
+        },
+        42
+      )
+    ).rejects.toThrow('binding is required');
+
+    expect(store.delete).not.toHaveBeenCalledWith('installation:42');
   });
 
   it('rejects unsigned deliveries and fails visibly when deletion storage is unavailable', async () => {
@@ -328,7 +454,8 @@ describe('installation retention safeguards', () => {
     expect(response.status).toBe(202);
     expect(confirmInstallationIsInactive).toHaveBeenCalledTimes(2);
     expect(store.put).toHaveBeenCalledOnce();
-    expect(store.delete).toHaveBeenCalledExactlyOnceWith('installation:42');
+    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation-usage:42');
+    expect(store.delete).toHaveBeenNthCalledWith(2, 'installation:42');
   });
 
   it('paginates GitHub’s active-installation list', async () => {
@@ -416,9 +543,10 @@ describe('installation retention safeguards', () => {
       limit: 25,
       cursor: 'next-page',
     });
-    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation:2');
-    expect(store.delete).toHaveBeenNthCalledWith(2, INSTALLATION_CLEANUP_CHECKPOINT_KEY);
-    expect(store.delete).toHaveBeenCalledTimes(2);
+    expect(store.delete).toHaveBeenNthCalledWith(1, 'installation-usage:2');
+    expect(store.delete).toHaveBeenNthCalledWith(2, 'installation:2');
+    expect(store.delete).toHaveBeenNthCalledWith(3, INSTALLATION_CLEANUP_CHECKPOINT_KEY);
+    expect(store.delete).toHaveBeenCalledTimes(3);
     expect(store.put).toHaveBeenNthCalledWith(
       1,
       INSTALLATION_CLEANUP_CHECKPOINT_KEY,

--- a/test/socialProofConsent.test.ts
+++ b/test/socialProofConsent.test.ts
@@ -106,6 +106,78 @@ describe('social proof consent workflow', () => {
     ]);
   });
 
+  it('keeps the newest reinstall even when an older installation had more usage', () => {
+    const old = record(1, 'same-app');
+    const current = { ...record(2, 'same-app'), installedAt: '2026-08-31T00:00:00.000Z' };
+    const usage = [
+      { schemaVersion: 1, installationId: 1, successfulFeedbackCount: 20 },
+      { schemaVersion: 1, installationId: 2, successfulFeedbackCount: 3 },
+    ];
+
+    expect(
+      buildCandidateReview(
+        [current, old],
+        registry(),
+        ['owned-account'],
+        fingerprintKey,
+        generatedAt,
+        usage
+      ).candidates
+    ).toEqual([
+      {
+        account: current.account,
+        installedAt: current.installedAt,
+        accountFingerprint: fingerprint('same-app'),
+        successfulFeedbackCount: 3,
+      },
+    ]);
+  });
+
+  it('joins exact private usage by installation and ranks known high-use candidates first', () => {
+    const records = [record(1, 'low-use'), record(2, 'unknown-use'), record(3, 'high-use')];
+    const usage = [
+      { schemaVersion: 1, installationId: 1, successfulFeedbackCount: 2 },
+      { schemaVersion: 1, installationId: 3, successfulFeedbackCount: 19 },
+    ];
+
+    const candidates = buildCandidateReview(
+      records,
+      registry(),
+      ['owned-account'],
+      fingerprintKey,
+      generatedAt,
+      usage
+    ).candidates;
+
+    expect(candidates.map(candidate => candidate.account.login)).toEqual([
+      'high-use',
+      'low-use',
+      'unknown-use',
+    ]);
+    expect(candidates[0].successfulFeedbackCount).toBe(19);
+    expect(candidates[2]).not.toHaveProperty('successfulFeedbackCount');
+  });
+
+  it('rejects usage records with extra or identifying fields', () => {
+    expect(() =>
+      buildCandidateReview(
+        [record(1, 'candidate')],
+        registry(),
+        ['owned-account'],
+        fingerprintKey,
+        generatedAt,
+        [
+          {
+            schemaVersion: 1,
+            installationId: 1,
+            successfulFeedbackCount: 3,
+            repository: 'private/repo',
+          },
+        ]
+      )
+    ).toThrow('Invalid installation usage record');
+  });
+
   it('requires and applies case-insensitive owned and test account exclusions', () => {
     const records = [record(1, 'neonwatty'), record(2, 'Real-App')];
     const decisions = registry();

--- a/test/structuredFeedback.test.ts
+++ b/test/structuredFeedback.test.ts
@@ -18,6 +18,10 @@ class TestGitHubLabelError extends Error {
 
 vi.mock('../src/lib/github', () => ({
   getInstallationToken: (...arguments_: unknown[]) => mockGetInstallationToken(...arguments_),
+  getInstallationAccess: async (...arguments_: unknown[]) => {
+    const token = await mockGetInstallationToken(...arguments_);
+    return token ? { token, installationId: 123456 } : null;
+  },
   createIssue: (...arguments_: unknown[]) => mockCreateIssue(...arguments_),
   isRepoPublic: (...arguments_: unknown[]) => mockIsRepoPublic(...arguments_),
   uploadScreenshotAsAsset: vi.fn(),


### PR DESCRIPTION
## Summary

- count successful GitHub Issues per GitHub App installation using the existing Durable Object and analytics KV bindings
- keep the feature fail-closed and disabled unless `INSTALLATION_USAGE_ENABLED` is exactly `true`
- rank the private consent-review candidates by exact successful-feedback count without exposing counts publicly
- delete usage with installation identity and protect uninstall races without storing repositories, Issue content, reporters, or submission timestamps

## Rollout boundary

This PR does not enable collection. Publish the matching privacy disclosure first, then enable the flag and run the documented controlled-installation canary.

## Verification

- `npm run validate` (101 files, 1,588 tests)
- `npx wrangler deploy --dry-run --env preview`
- PR Review Toolkit: no remaining high-confidence findings after fixes

The preview dry run retains the existing unrelated warning about board variables not being inherited by the preview environment.