### PR TITLE
feat: reconcile existing GitHub installations

### DIFF
--- a/docs/installation-usage-counting.md
+++ b/docs/installation-usage-counting.md
@@ -53,8 +53,17 @@ The mirror is not created until the installation identity record is visible. If 
 still propagating, the Durable Object makes at most 1,440 one-minute retry checks without resetting
 the original budget. The budget is a non-temporal integer; no submission timestamp is stored. If no
 identity arrives, it purges the unanchored counter instead of retaining usage that the scheduled
-cleanup cannot discover. This intentionally favors deletion safety over completeness for a
-pre-tracking installation or a permanently missed installation-created webhook.
+cleanup cannot discover. Before cleanup, the same daily task finds active GitHub App installations
+that lack an identity record and creates those missing records using the approved minimal schema. It stores an
+aggregate-only audit, and reuses the fetched installation set for cleanup. That idempotent repair
+lets installations from before tracking—and installations whose creation webhook was permanently
+missed—begin prospective counting without a reinstall. The reconciliation code also supports a
+non-writing dry run for controlled verification. Active installations without a supported GitHub
+User or Organization identity remain part of cleanup but are skipped by reconciliation and counted
+only in the aggregate audit. Apply repairs at most 25 records at a time and reports the remaining
+aggregate count so large inventories finish safely over later daily runs. Each repair candidate is
+confirmed active immediately after creation; an uninstall racing the repair triggers the
+same complete identity-and-usage cleanup as an uninstall webhook.
 
 Delivery uses one opaque event ID across retries, so an ambiguous retry does not increment twice.
 It has the same best-effort delivery boundary as the existing anonymous public counter; it is not a

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import api from './routes/api';
 import githubWebhook from './routes/github-webhook';
 import { createBoardDogfoodToken } from './lib/boardDogfood';
 import { sweepInstallationRecords } from './lib/installation-retention';
+import { listActiveGitHubInstallations } from './lib/github-installation-inventory';
+import { reconcileInstallationRecords } from './lib/installation-reconciliation';
 
 export { FeedbackCounter } from './lib/feedback-counter';
 
@@ -151,7 +153,13 @@ export async function scheduled(
   env: Env,
   _ctx: ExecutionContext
 ): Promise<void> {
-  await sweepInstallationRecords(env);
+  await sweepInstallationRecords(env, {
+    listActiveInstallationIds: async () => {
+      const inventory = await listActiveGitHubInstallations(env);
+      await reconcileInstallationRecords(env, { mode: 'apply', inventory });
+      return new Set(inventory.installationIds);
+    },
+  });
 }
 
 export default {

--- a/src/lib/github-installation-inventory.ts
+++ b/src/lib/github-installation-inventory.ts
@@ -1,0 +1,121 @@
+import { generateGitHubAppJWT } from './jwt';
+import { GITHUB_API, githubHeaders } from './github';
+import {
+  isCanonicalGitHubProfileUrl,
+  isGitHubAccountLogin,
+  isInstallationAccountType,
+  type NewInstallationRecord,
+} from './installation-analytics';
+import type { Env } from '../types';
+
+const GITHUB_PAGE_SIZE = 100;
+export const MAX_GITHUB_INSTALLATION_PAGES = 20;
+
+interface GitHubListOptions {
+  fetchImpl?: typeof fetch;
+  createJwt?: (appId: string, privateKey: string) => Promise<string>;
+}
+
+export interface GitHubInstallationInventory {
+  installationIds: number[];
+  records: NewInstallationRecord[];
+  skippedCount: number;
+  pageCount: number;
+}
+
+export async function listActiveGitHubInstallations(
+  env: Env,
+  options: GitHubListOptions = {}
+): Promise<GitHubInstallationInventory> {
+  if (!env.GITHUB_APP_ID || !env.GITHUB_PRIVATE_KEY) {
+    throw new Error('GitHub App credentials are required for installation reconciliation');
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const createJwt = options.createJwt ?? generateGitHubAppJWT;
+  const jwt = await createJwt(env.GITHUB_APP_ID, env.GITHUB_PRIVATE_KEY);
+  const installationIds = new Set<number>();
+  const records: NewInstallationRecord[] = [];
+  let skippedCount = 0;
+
+  for (let page = 1; page <= MAX_GITHUB_INSTALLATION_PAGES; page += 1) {
+    const response = await fetchImpl(
+      `${GITHUB_API}/app/installations?per_page=${GITHUB_PAGE_SIZE}&page=${page}`,
+      { headers: githubHeaders(jwt) }
+    );
+    if (!response.ok) {
+      throw new Error(`Failed to list GitHub App installations: ${response.status}`);
+    }
+
+    const installations = (await response.json()) as unknown;
+    if (!Array.isArray(installations)) {
+      throw new Error('GitHub returned an invalid installation list');
+    }
+    for (const value of installations) {
+      const installation = installationFromGitHub(value);
+      if (installationIds.has(installation.installationId)) {
+        throw new Error('GitHub returned a duplicate installation');
+      }
+      installationIds.add(installation.installationId);
+      if (installation.record) records.push(installation.record);
+      else skippedCount += 1;
+    }
+    if (installations.length < GITHUB_PAGE_SIZE) {
+      return { installationIds: [...installationIds], records, skippedCount, pageCount: page };
+    }
+  }
+
+  throw new Error('GitHub installation pagination exceeded the safety limit');
+}
+
+function installationFromGitHub(value: unknown): {
+  installationId: number;
+  record: NewInstallationRecord | null;
+} {
+  if (!value || typeof value !== 'object') {
+    throw new Error('GitHub returned an invalid installation record');
+  }
+  const candidate = value as {
+    id?: unknown;
+    account?: { login?: unknown; type?: unknown; html_url?: unknown };
+    created_at?: unknown;
+  };
+  if (
+    typeof candidate.id !== 'number' ||
+    !Number.isSafeInteger(candidate.id) ||
+    candidate.id <= 0
+  ) {
+    throw new Error('GitHub returned an invalid installation record');
+  }
+  const account = candidate.account;
+  if (!account || !isInstallationAccountType(account.type)) {
+    return { installationId: candidate.id, record: null };
+  }
+  const installedAt = normalizeGitHubDate(candidate.created_at);
+  if (
+    typeof account.login !== 'string' ||
+    !isGitHubAccountLogin(account.login) ||
+    typeof account.html_url !== 'string' ||
+    !isCanonicalGitHubProfileUrl(account.html_url, account.login) ||
+    !installedAt
+  ) {
+    throw new Error('GitHub returned an invalid installation record');
+  }
+  return {
+    installationId: candidate.id,
+    record: {
+      installationId: candidate.id,
+      account: {
+        login: account.login,
+        type: account.type,
+        profileUrl: account.html_url,
+      },
+      installedAt,
+    },
+  };
+}
+
+function normalizeGitHubDate(value: unknown): string | null {
+  if (typeof value !== 'string' || Number.isNaN(Date.parse(value))) return null;
+  return new Date(value).toISOString();
+}

--- a/src/lib/installation-analytics.ts
+++ b/src/lib/installation-analytics.ts
@@ -29,13 +29,13 @@ export function installationRecordKey(installationId: number): string {
 export async function createInstallationRecord(
   store: KVNamespace,
   installation: NewInstallationRecord
-): Promise<void> {
+): Promise<boolean> {
   const key = installationRecordKey(installation.installationId);
   const existing = await store.get(key);
   if (existing !== null) {
     const record = parseInstallationIdentityRecord(existing, installation.installationId);
     assertInstallationIdentityRecord(record, installation.installationId);
-    return;
+    return false;
   }
 
   const record: InstallationIdentityRecord = {
@@ -46,6 +46,7 @@ export async function createInstallationRecord(
   };
   assertInstallationIdentityRecord(record, installation.installationId);
   await store.put(key, JSON.stringify(record));
+  return true;
 }
 
 function parseInstallationIdentityRecord(value: string, installationId: number): unknown {

--- a/src/lib/installation-reconciliation.ts
+++ b/src/lib/installation-reconciliation.ts
@@ -1,0 +1,125 @@
+import { INSTALLATION_RECORD_PREFIX, createInstallationRecord } from './installation-analytics';
+import {
+  confirmGitHubInstallationIsInactive,
+  deleteInstallationData,
+  INSTALLATION_SWEEP_PAGE_SIZE,
+} from './installation-retention';
+import {
+  listActiveGitHubInstallations,
+  type GitHubInstallationInventory,
+} from './github-installation-inventory';
+import type { Env } from '../types';
+
+const STORED_RECORD_PAGE_SIZE = 1000;
+const MAX_STORED_RECORD_PAGES = 20;
+const INSTALLATION_RECONCILIATION_BATCH_SIZE = 25;
+export const MAX_SCHEDULED_GITHUB_REQUESTS = 50;
+export const INSTALLATION_RECONCILIATION_AUDIT_KEY =
+  'operations:installation-reconciliation:last-success';
+
+type ReconciliationMode = 'dry-run' | 'apply';
+
+interface ReconciliationOptions {
+  mode?: ReconciliationMode;
+  now?: Date;
+  inventory?: GitHubInstallationInventory;
+  confirmInactive?: (env: Env, installationId: number) => Promise<boolean>;
+  deleteInstallation?: (env: Env, installationId: number) => Promise<void>;
+}
+
+interface InstallationReconciliationAudit {
+  schemaVersion: 1;
+  mode: ReconciliationMode;
+  completedAt: string;
+  activeCount: number;
+  eligibleCount: number;
+  skippedCount: number;
+  existingCount: number;
+  missingCount: number;
+  processedCount: number;
+  createdCount: number;
+  inactiveCount: number;
+  remainingCount: number;
+}
+
+export async function reconcileInstallationRecords(
+  env: Env,
+  options: ReconciliationOptions = {}
+): Promise<InstallationReconciliationAudit> {
+  const store = env.INSTALLATION_ANALYTICS;
+  if (!store) throw new Error('INSTALLATION_ANALYTICS binding is required for reconciliation');
+
+  const mode = options.mode ?? 'dry-run';
+  const inventory = options.inventory ?? (await listActiveGitHubInstallations(env));
+  const storedIds = await listStoredInstallationIds(store);
+  const missing = inventory.records.filter(record => !storedIds.has(record.installationId));
+  let createdCount = 0;
+  let inactiveCount = 0;
+  let processedCount = 0;
+
+  if (mode === 'apply') {
+    const confirmInactive = options.confirmInactive ?? confirmGitHubInstallationIsInactive;
+    const deleteInstallation = options.deleteInstallation ?? deleteInstallationData;
+    const batchSize = Math.max(
+      0,
+      Math.min(
+        INSTALLATION_RECONCILIATION_BATCH_SIZE,
+        MAX_SCHEDULED_GITHUB_REQUESTS - inventory.pageCount - INSTALLATION_SWEEP_PAGE_SIZE
+      )
+    );
+    for (const installation of missing.slice(0, batchSize)) {
+      processedCount += 1;
+      const created = await createInstallationRecord(store, installation);
+      if (await confirmInactive(env, installation.installationId)) {
+        await deleteInstallation(env, installation.installationId);
+        inactiveCount += 1;
+      } else if (created) {
+        createdCount += 1;
+      }
+    }
+  }
+
+  const audit: InstallationReconciliationAudit = {
+    schemaVersion: 1,
+    mode,
+    completedAt: (options.now ?? new Date()).toISOString(),
+    activeCount: inventory.installationIds.length,
+    eligibleCount: inventory.records.length,
+    skippedCount: inventory.skippedCount,
+    existingCount: inventory.records.length - missing.length,
+    missingCount: missing.length,
+    processedCount,
+    createdCount,
+    inactiveCount,
+    remainingCount: missing.length - processedCount,
+  };
+  if (mode === 'apply') {
+    await store.put(INSTALLATION_RECONCILIATION_AUDIT_KEY, JSON.stringify(audit));
+  }
+  return audit;
+}
+
+async function listStoredInstallationIds(store: KVNamespace): Promise<Set<number>> {
+  const ids = new Set<number>();
+  let cursor: string | undefined;
+  for (let pageNumber = 0; pageNumber < MAX_STORED_RECORD_PAGES; pageNumber += 1) {
+    const page = await store.list({
+      prefix: INSTALLATION_RECORD_PREFIX,
+      limit: STORED_RECORD_PAGE_SIZE,
+      ...(cursor ? { cursor } : {}),
+    });
+    for (const key of page.keys) {
+      const rawId = key.name.slice(INSTALLATION_RECORD_PREFIX.length);
+      if (!/^\d+$/.test(rawId)) throw new Error('Malformed installation record key');
+      const id = Number(rawId);
+      if (!Number.isSafeInteger(id) || id <= 0) {
+        throw new Error('Malformed installation record key');
+      }
+      ids.add(id);
+    }
+    if (page.list_complete) return ids;
+    if (!page.cursor) throw new Error('Installation record pagination omitted its cursor');
+    cursor = page.cursor;
+  }
+  throw new Error('Installation record pagination exceeded the safety limit');
+}

--- a/src/lib/installation-retention.ts
+++ b/src/lib/installation-retention.ts
@@ -1,6 +1,7 @@
 import { generateGitHubAppJWT } from './jwt';
 import { GITHUB_API, githubHeaders } from './github';
 import { INSTALLATION_RECORD_PREFIX, installationRecordKey } from './installation-analytics';
+import { listActiveGitHubInstallations } from './github-installation-inventory';
 import {
   deleteInstallationFeedbackCounter,
   purgeInstallationFeedbackCounter,
@@ -20,8 +21,7 @@ import type { Env } from '../types';
 
 export type { InstallationCleanupAudit } from './installation-cleanup-state';
 
-const GITHUB_PAGE_SIZE = 100;
-export const MAX_GITHUB_INSTALLATION_PAGES = 20;
+export { MAX_GITHUB_INSTALLATION_PAGES } from './github-installation-inventory';
 export const INSTALLATION_SWEEP_PAGE_SIZE = 25;
 export const MAX_CONCURRENT_CLEANUP_OPERATIONS = 6;
 
@@ -90,41 +90,8 @@ export async function listActiveGitHubInstallationIds(
   env: Env,
   options: GitHubListOptions = {}
 ): Promise<Set<number>> {
-  if (!env.GITHUB_APP_ID || !env.GITHUB_PRIVATE_KEY) {
-    throw new Error('GitHub App credentials are required for installation cleanup');
-  }
-
-  const fetchImpl = options.fetchImpl ?? fetch;
-  const createJwt = options.createJwt ?? generateGitHubAppJWT;
-  const jwt = await createJwt(env.GITHUB_APP_ID, env.GITHUB_PRIVATE_KEY);
-  const activeIds = new Set<number>();
-
-  for (let page = 1; page <= MAX_GITHUB_INSTALLATION_PAGES; page += 1) {
-    const response = await fetchImpl(
-      `${GITHUB_API}/app/installations?per_page=${GITHUB_PAGE_SIZE}&page=${page}`,
-      {
-        headers: githubHeaders(jwt),
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error(`Failed to list GitHub App installations: ${response.status}`);
-    }
-
-    const installations = (await response.json()) as unknown;
-    if (!Array.isArray(installations)) {
-      throw new Error('GitHub returned an invalid installation list');
-    }
-
-    for (const installation of installations) {
-      const id = installationIdFromGitHub(installation);
-      activeIds.add(id);
-    }
-
-    if (installations.length < GITHUB_PAGE_SIZE) return activeIds;
-  }
-
-  throw new Error('GitHub installation pagination exceeded the safety limit');
+  const inventory = await listActiveGitHubInstallations(env, options);
+  return new Set(inventory.installationIds);
 }
 
 export async function confirmGitHubInstallationIsInactive(
@@ -279,17 +246,6 @@ async function listStoredInstallationPage(
   }
 
   return { ids, ...(page.list_complete ? {} : { cursor: page.cursor }) };
-}
-
-function installationIdFromGitHub(value: unknown): number {
-  if (!value || typeof value !== 'object' || !('id' in value)) {
-    throw new Error('GitHub returned an invalid installation record');
-  }
-  const id = (value as { id: unknown }).id;
-  if (typeof id !== 'number' || !Number.isSafeInteger(id) || id <= 0) {
-    throw new Error('GitHub returned an invalid installation ID');
-  }
-  return id;
 }
 
 function hexToBytes(hex: string): Uint8Array | null {

--- a/test/installationReconciliation.test.ts
+++ b/test/installationReconciliation.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Env } from '../src/types';
+import {
+  INSTALLATION_RECONCILIATION_AUDIT_KEY,
+  MAX_SCHEDULED_GITHUB_REQUESTS,
+  reconcileInstallationRecords,
+} from '../src/lib/installation-reconciliation';
+import {
+  MAX_GITHUB_INSTALLATION_PAGES,
+  listActiveGitHubInstallations,
+} from '../src/lib/github-installation-inventory';
+import type { NewInstallationRecord } from '../src/lib/installation-analytics';
+import { INSTALLATION_SWEEP_PAGE_SIZE } from '../src/lib/installation-retention';
+
+const baseEnv: Env = {
+  GITHUB_APP_ID: '123',
+  GITHUB_PRIVATE_KEY: 'test-private-key',
+  ENVIRONMENT: 'test',
+  ALLOWED_ORIGINS: '*',
+  GITHUB_APP_NAME: 'test-bugdrop-app',
+  MAX_SCREENSHOT_SIZE_MB: '5',
+  ASSETS: {} as Fetcher,
+};
+
+function activeInstallation(id: number): NewInstallationRecord {
+  return {
+    installationId: id,
+    account: {
+      login: `app-${id}`,
+      type: 'Organization',
+      profileUrl: `https://github.com/app-${id}`,
+    },
+    installedAt: '2026-08-28T12:00:00.000Z',
+  };
+}
+
+function inventory(records: NewInstallationRecord[], pageCount = 1) {
+  return {
+    installationIds: records.map(record => record.installationId),
+    records,
+    skippedCount: 0,
+    pageCount,
+  };
+}
+
+function createStore(initial: Record<string, string> = {}): {
+  store: KVNamespace;
+  values: Map<string, string>;
+  put: ReturnType<typeof vi.fn>;
+} {
+  const values = new Map(Object.entries(initial));
+  const put = vi.fn(async (key: string, value: string) => {
+    values.set(key, value);
+  });
+  return {
+    values,
+    put,
+    store: {
+      get: vi.fn(async (key: string) => values.get(key) ?? null),
+      put,
+      delete: vi.fn(async (key: string) => {
+        values.delete(key);
+      }),
+      getWithMetadata: vi.fn(),
+      list: vi.fn(async () => ({
+        keys: [...values.keys()]
+          .filter(name => name.startsWith('installation:'))
+          .map(name => ({ name })),
+        list_complete: true,
+        cacheStatus: null,
+      })),
+    } as unknown as KVNamespace,
+  };
+}
+
+describe('active installation reconciliation', () => {
+  it('normalizes only the approved minimal identity fields from GitHub', async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json([
+        {
+          id: 42,
+          account: {
+            login: 'acme',
+            type: 'Organization',
+            html_url: 'https://github.com/acme',
+            email: 'private@example.com',
+          },
+          created_at: '2026-08-28T05:00:00-07:00',
+          repositories_url: 'https://api.github.com/installation/repositories',
+          repository_selection: 'all',
+        },
+        {
+          id: 43,
+          account: {
+            login: 'acme-enterprise',
+            type: 'Enterprise',
+            html_url: 'https://github.com/enterprises/acme',
+          },
+          created_at: '2026-08-28T12:00:00Z',
+        },
+      ])
+    );
+
+    const result = await listActiveGitHubInstallations(baseEnv, {
+      fetchImpl,
+      createJwt: vi.fn().mockResolvedValue('app-jwt'),
+    });
+
+    expect(result).toEqual({
+      installationIds: [42, 43],
+      skippedCount: 1,
+      pageCount: 1,
+      records: [
+        {
+          installationId: 42,
+          account: {
+            login: 'acme',
+            type: 'Organization',
+            profileUrl: 'https://github.com/acme',
+          },
+          installedAt: '2026-08-28T12:00:00.000Z',
+        },
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain('private@example.com');
+    expect(JSON.stringify(result)).not.toContain('repositories');
+  });
+
+  it('reports a dry run without writing records or an audit', async () => {
+    const existing = activeInstallation(1);
+    const { store, put } = createStore({
+      'installation:1': JSON.stringify({ schemaVersion: 1, ...existing }),
+    });
+
+    const audit = await reconcileInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {
+        mode: 'dry-run',
+        now: new Date('2026-08-31T12:00:00.000Z'),
+        inventory: inventory([existing, activeInstallation(2)]),
+      }
+    );
+
+    expect(audit).toEqual({
+      schemaVersion: 1,
+      mode: 'dry-run',
+      completedAt: '2026-08-31T12:00:00.000Z',
+      activeCount: 2,
+      eligibleCount: 2,
+      skippedCount: 0,
+      existingCount: 1,
+      missingCount: 1,
+      processedCount: 0,
+      createdCount: 0,
+      inactiveCount: 0,
+      remainingCount: 1,
+    });
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it('creates only missing records, writes aggregate evidence, and is idempotent', async () => {
+    const existing = activeInstallation(1);
+    const missing = activeInstallation(2);
+    const { store, values } = createStore({
+      'installation:1': JSON.stringify({ schemaVersion: 1, ...existing }),
+    });
+    const env = { ...baseEnv, INSTALLATION_ANALYTICS: store };
+
+    const first = await reconcileInstallationRecords(env, {
+      mode: 'apply',
+      now: new Date('2026-08-31T12:00:00.000Z'),
+      inventory: inventory([existing, missing]),
+      confirmInactive: vi.fn().mockResolvedValue(false),
+    });
+    const second = await reconcileInstallationRecords(env, {
+      mode: 'apply',
+      now: new Date('2026-08-31T13:00:00.000Z'),
+      inventory: inventory([existing, missing]),
+      confirmInactive: vi.fn().mockResolvedValue(false),
+    });
+
+    expect(first).toMatchObject({
+      existingCount: 1,
+      missingCount: 1,
+      processedCount: 1,
+      createdCount: 1,
+      remainingCount: 0,
+    });
+    expect(second).toMatchObject({
+      existingCount: 2,
+      missingCount: 0,
+      processedCount: 0,
+      createdCount: 0,
+      remainingCount: 0,
+    });
+    expect(JSON.parse(values.get('installation:2')!)).toEqual({
+      schemaVersion: 1,
+      ...missing,
+    });
+    expect(JSON.parse(values.get(INSTALLATION_RECONCILIATION_AUDIT_KEY)!)).toEqual(second);
+  });
+
+  it('resumes safely after a partial write failure without publishing a false audit', async () => {
+    const { store, values } = createStore();
+    const originalPut = store.put.bind(store);
+    let interrupted = false;
+    store.put = vi.fn(async (key: string, value: string, options?: KVNamespacePutOptions) => {
+      if (key === 'installation:2' && !interrupted) {
+        interrupted = true;
+        throw new Error('temporary KV failure');
+      }
+      await originalPut(key, value, options);
+    });
+    const env = { ...baseEnv, INSTALLATION_ANALYTICS: store };
+    const active = [activeInstallation(1), activeInstallation(2)];
+
+    await expect(
+      reconcileInstallationRecords(env, {
+        mode: 'apply',
+        inventory: inventory(active),
+        confirmInactive: vi.fn().mockResolvedValue(false),
+      })
+    ).rejects.toThrow('temporary KV failure');
+    expect(values.has('installation:1')).toBe(true);
+    expect(values.has('installation:2')).toBe(false);
+    expect(values.has(INSTALLATION_RECONCILIATION_AUDIT_KEY)).toBe(false);
+
+    const retry = await reconcileInstallationRecords(env, {
+      mode: 'apply',
+      now: new Date('2026-08-31T14:00:00.000Z'),
+      inventory: inventory(active),
+      confirmInactive: vi.fn().mockResolvedValue(false),
+    });
+    expect(retry).toMatchObject({
+      existingCount: 1,
+      missingCount: 1,
+      processedCount: 1,
+      createdCount: 1,
+      remainingCount: 0,
+    });
+    expect(values.has('installation:2')).toBe(true);
+    expect(values.has(INSTALLATION_RECONCILIATION_AUDIT_KEY)).toBe(true);
+  });
+
+  it('bounds each apply run and continues with the remaining missing records later', async () => {
+    const { store, values } = createStore();
+    const safeBatchSize =
+      MAX_SCHEDULED_GITHUB_REQUESTS - MAX_GITHUB_INSTALLATION_PAGES - INSTALLATION_SWEEP_PAGE_SIZE;
+    const records = Array.from({ length: safeBatchSize + 5 }, (_, index) =>
+      activeInstallation(index + 1)
+    );
+
+    const audit = await reconcileInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {
+        mode: 'apply',
+        inventory: inventory(records, MAX_GITHUB_INSTALLATION_PAGES),
+        confirmInactive: vi.fn().mockResolvedValue(false),
+      }
+    );
+
+    expect(audit).toMatchObject({
+      missingCount: safeBatchSize + 5,
+      processedCount: safeBatchSize,
+      createdCount: safeBatchSize,
+      remainingCount: 5,
+    });
+    expect([...values.keys()].filter(key => /^installation:\d+$/.test(key))).toHaveLength(
+      safeBatchSize
+    );
+    expect(
+      MAX_GITHUB_INSTALLATION_PAGES + safeBatchSize + INSTALLATION_SWEEP_PAGE_SIZE
+    ).toBeLessThanOrEqual(MAX_SCHEDULED_GITHUB_REQUESTS);
+  });
+
+  it('removes a record when uninstall races reconciliation after creation', async () => {
+    const { store, values } = createStore();
+    const confirmInactive = vi.fn().mockResolvedValue(true);
+    const deleteInstallation = vi.fn(async (_env: Env, installationId: number) => {
+      await store.delete(`installation:${installationId}`);
+    });
+
+    const audit = await reconcileInstallationRecords(
+      { ...baseEnv, INSTALLATION_ANALYTICS: store },
+      {
+        mode: 'apply',
+        inventory: inventory([activeInstallation(42)]),
+        confirmInactive,
+        deleteInstallation,
+      }
+    );
+
+    expect(confirmInactive).toHaveBeenCalledOnce();
+    expect(deleteInstallation).toHaveBeenCalledOnce();
+    expect(values.has('installation:42')).toBe(false);
+    expect(audit).toMatchObject({
+      processedCount: 1,
+      createdCount: 0,
+      inactiveCount: 1,
+      remainingCount: 0,
+    });
+  });
+
+  it('fails closed on malformed or duplicate GitHub installation records', async () => {
+    const malformed = vi.fn<typeof fetch>().mockResolvedValue(
+      Response.json([
+        {
+          id: 42,
+          account: { login: 'acme', type: 'Organization', html_url: 'https://evil.example/acme' },
+          created_at: '2026-08-28T12:00:00Z',
+        },
+      ])
+    );
+    await expect(
+      listActiveGitHubInstallations(baseEnv, {
+        fetchImpl: malformed,
+        createJwt: vi.fn().mockResolvedValue('app-jwt'),
+      })
+    ).rejects.toThrow('invalid installation record');
+
+    const valid = {
+      id: 42,
+      account: { login: 'acme', type: 'Organization', html_url: 'https://github.com/acme' },
+      created_at: '2026-08-28T12:00:00Z',
+    };
+    await expect(
+      listActiveGitHubInstallations(baseEnv, {
+        fetchImpl: vi.fn<typeof fetch>().mockResolvedValue(Response.json([valid, valid])),
+        createJwt: vi.fn().mockResolvedValue('app-jwt'),
+      })
+    ).rejects.toThrow('duplicate installation');
+  });
+});

--- a/test/installationRetention.test.ts
+++ b/test/installationRetention.test.ts
@@ -459,11 +459,20 @@ describe('installation retention safeguards', () => {
   });
 
   it('paginates GitHub’s active-installation list', async () => {
-    const firstPage = Array.from({ length: 100 }, (_, index) => ({ id: index + 1 }));
+    const installation = (id: number) => ({
+      id,
+      account: {
+        login: `app-${id}`,
+        type: 'Organization',
+        html_url: `https://github.com/app-${id}`,
+      },
+      created_at: '2026-08-28T12:00:00Z',
+    });
+    const firstPage = Array.from({ length: 100 }, (_, index) => installation(index + 1));
     const fetchImpl = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(Response.json(firstPage))
-      .mockResolvedValueOnce(Response.json([{ id: 101 }]));
+      .mockResolvedValueOnce(Response.json([installation(101)]));
 
     const ids = await listActiveGitHubInstallationIds(baseEnv, {
       fetchImpl,


### PR DESCRIPTION
## Summary
- reconcile active GitHub App installations that are missing the approved minimal identity record
- reuse the daily GitHub inventory for retention cleanup and keep aggregate requests within the Worker safety budget
- make repair bounded, idempotent, race-safe, and observable through an aggregate-only last-success audit

## Privacy and rollout
- stores no repository, Issue, reporter, email, or activity-timestamp data
- usage remains prospective and gated by `INSTALLATION_USAGE_ENABLED`
- does not backfill historical usage or require a new database

## Verification
- `npm run validate` (102 files, 1,595 tests)
- `make check` (including 449 release tests and workflow/security contracts)
- focused reconciliation, retention, cleanup durability, and request-budget tests (34 tests)
- PR review toolkit: no high-confidence findings after fixes