### PR TITLE
docs: clarify repository access and installation version policy

### DIFF
--- a/docs/website/faq.mdx
+++ b/docs/website/faq.mdx
@@ -61,14 +61,15 @@ Screenshots are stored as image files in a `.bugdrop/` directory on the `bugdrop
 
 ### What permissions does the GitHub App need?
 
-The BugDrop GitHub App requests two permissions:
+The BugDrop GitHub App uses these repository permissions:
 
 | Permission | Access Level | Purpose |
 |-----------|-------------|---------|
 | **Issues** | Read & Write | Create bug reports as GitHub Issues |
-| **Contents** | Read & Write | Store screenshots on the `bugdrop-screenshots` branch |
+| **Contents** | Read & Write | Store screenshots and attachments on the `bugdrop-screenshots` branch |
+| **Metadata** | Read | Read basic repository information |
 
-These are the minimum permissions required. The app does not access your source code, pull requests, actions, secrets, or any other repository data.
+**Contents permission includes access to source files.** It applies to the selected repository, not only the screenshots branch. BugDrop’s file-upload implementation stores screenshots and attachments on that branch, but the permission itself is broader. Choose **Only select repositories** during installation to limit access, and review the [permission and data-handling explanation](/docs/security#github-app-permissions).
 
 ### Can I use BugDrop on multiple repos?
 
@@ -76,11 +77,11 @@ Yes. When you install the BugDrop GitHub App, you can grant access to specific r
 
 ```html
 <!-- Site A -->
-<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+<script src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="your-org/site-a"></script>
 
 <!-- Site B -->
-<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+<script src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="your-org/site-b"></script>
 ```
 
@@ -107,7 +108,7 @@ BugDrop reads configuration from the script element that is executing. Use the o
 Yes. The `data-label` attribute changes the text displayed next to the button icon:
 
 ```html
-<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+<script src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="owner/repo"
   data-label="Send Feedback"></script>
 ```
@@ -115,7 +116,7 @@ Yes. The `data-label` attribute changes the text displayed next to the button ic
 You can also set `data-icon="none"` to show only the text label without an icon:
 
 ```html
-<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+<script src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="owner/repo"
   data-icon="none"
   data-label="Report a Bug"></script>
@@ -126,7 +127,7 @@ You can also set `data-icon="none"` to show only the text label without an icon:
 Yes. Self-hosted deployments can map the three built-in categories to custom GitHub labels with `data-category-labels` when `ALLOW_CLIENT_CATEGORY_LABELS` is set to `"true"`:
 
 ```html
-<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+<script src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="owner/repo"
   data-category-labels='{"bug":"defect","feature":["product-feedback","triage"],"question":"support"}'></script>
 ```
@@ -143,7 +144,7 @@ Yes. By default, the name and email fields are hidden. Enable them with data att
 
 ```html
 <!-- Show both, require email -->
-<script src="https://bugdrop.neonwatty.workers.dev/widget.js"
+<script src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="owner/repo"
   data-show-name="true"
   data-show-email="true"

--- a/docs/website/installation.mdx
+++ b/docs/website/installation.mdx
@@ -1,8 +1,6 @@
 # Installation
 
-import { WidgetInstallSnippet } from "@/components/widget-install-snippet";
-
-Getting BugDrop running on your site takes about 30 seconds. There are only two steps: install the GitHub App and add a script tag. No npm packages, no build configuration, no backend setup required.
+Connect a GitHub repository, add one script tag, then send a test report. No npm package or backend setup is required for the hosted service. Allow time for any organization approval, site deployment, and testing your setup needs.
 
 ## Step 1: Install the GitHub App
 
@@ -10,24 +8,34 @@ BugDrop needs access to your GitHub repository to create issues and store screen
 
 **[Install BugDrop from GitHub Marketplace](https://github.com/marketplace/bugdrop-in-app-feedback-to-github-issues)**
 
-During installation you will be asked which repositories to grant access to. You can choose specific repositories or grant access to all repositories in your account or organization.
+During installation you will be asked which repositories to grant access to. Choose **Only select repositories** and select the repository that should receive feedback to limit the app’s access. Organization installations may require an administrator’s approval.
 
 ### What permissions does the app request?
 
 | Permission | Access Level | Purpose |
 |-----------|-------------|---------|
 | Issues | Read & Write | Create bug reports as GitHub Issues |
-| Contents | Read & Write | Store screenshots in the repository |
+| Contents | Read & Write | Store screenshots and attachments in the repository |
+| Metadata | Read | Read basic repository information; included with GitHub App repository access |
 
-These are the minimum permissions required for BugDrop to function. The app does not request access to your code, pull requests, actions, or any other repository data.
+**Contents access includes repository files, including source code.** GitHub grants this permission for the selected repository, not just a screenshot folder or branch. It permits reading and writing repository contents, subject to GitHub’s rules; see [GitHub’s Contents API documentation](https://docs.github.com/en/rest/repos/contents).
+
+BugDrop uses it to store screenshots and attachments on the `bugdrop-screenshots` branch. That describes the implementation’s use, not a narrower permission grant. Review [Security](/docs/security#github-app-permissions) before installing. You can change selected repositories or revoke access under **GitHub Settings > Applications > Installed GitHub Apps**.
 
 ## Step 2: Add the Script Tag
 
 Add the BugDrop script tag to your HTML, just before the closing `</body>` tag:
 
-<WidgetInstallSnippet repo="your-username/your-repo" />
+```html
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
+  data-repo="your-username/your-repo"
+></script>
+```
 
 Replace `your-username/your-repo` with your actual GitHub repository path (e.g., `acme-corp/my-website`).
+
+These installation examples use `widget.v1.56.4.js` so you can test a specific version before updating. The unversioned `widget.js` URL follows the current hosted deployment automatically. See [version pinning](/docs/version-pinning) for update options and hosting-availability limits, and use the same URL throughout your integration.
 
 ### Full HTML Example
 
@@ -44,7 +52,7 @@ Replace `your-username/your-repo` with your actual GitHub repository path (e.g.,
 
   <!-- BugDrop widget -->
   <script
-    src="https://bugdrop.neonwatty.workers.dev/widget.js"
+    src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
     data-repo="your-username/your-repo"
   ></script>
 </body>
@@ -57,7 +65,7 @@ You can add data attributes to customize the widget's appearance and behavior:
 
 ```html
 <script
-  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="your-username/your-repo"
   data-theme="dark"
   data-position="bottom-left"
@@ -88,9 +96,11 @@ BugDrop covers each marked element with an opaque rectangle on supported capture
 Password inputs and credit-card autocomplete fields are masked automatically. See
 [Screenshot masking](/docs/security#screenshot-masking) on the Security page for details.
 
-## Step 3: You Are Done
+## Step 3: Send a Test Report
 
-That is it. Load your page and you will see the BugDrop button in the corner of your site. Click it to open the feedback form, fill it out, and submit -- a GitHub Issue will be created in your repository automatically.
+Load your page, open the BugDrop button, and submit a clearly labeled test report with a screenshot. Confirm that the issue arrives in the selected repository and that its screenshot opens. A visible widget alone does not confirm that repository permissions, screenshot storage, and submission are working.
+
+Reports and screenshots in a public repository are public. Use non-sensitive test content, and review [screenshot masking](/docs/security#screenshot-masking) before using BugDrop on pages with customer data.
 
 ## Important Notes
 
@@ -98,7 +108,12 @@ That is it. Load your page and you will see the BugDrop button in the corner of 
 
 Use a normal script element without `async` or `defer`. The widget reads configuration from the executing script element, so changing execution order can separate initialization from its `data-*` attributes. This is the contract in the [official BugDrop README](https://github.com/mean-weasel/bugdrop#quick-start) and the same contract used by BugDrop's own website.
 
-<WidgetInstallSnippet />
+```html
+<script
+  src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
+  data-repo="owner/repo"
+></script>
+```
 
 ### Content Security Policy (CSP)
 
@@ -135,7 +150,7 @@ export default function RootLayout({ children }) {
       <body>
         {children}
         <script
-          src="https://bugdrop.neonwatty.workers.dev/widget.js"
+          src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
           data-repo="your-username/your-repo"
         />
       </body>

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -4,25 +4,19 @@ BugDrop is designed with security and privacy at its core. This page covers the 
 
 ## GitHub App Permissions
 
-The BugDrop GitHub App requests the minimum permissions necessary to function:
+The BugDrop GitHub App uses the following repository permissions:
 
 | Permission | Access Level | Purpose |
 |-----------|-------------|---------|
 | **Issues** | Read & Write | Create bug reports, feature requests, and questions as GitHub Issues |
-| **Contents** | Read & Write | Store screenshots in the repository on the `bugdrop-screenshots` branch |
+| **Contents** | Read & Write | Store screenshots and attachments on the `bugdrop-screenshots` branch |
+| **Metadata** | Read | Read basic repository information, including the default branch |
 
-GitHub App `Contents` permissions are repository-scoped, not branch-scoped. BugDrop's implementation writes screenshots only to `.bugdrop/screenshots/` on the dedicated `bugdrop-screenshots` branch, but GitHub does not provide a narrower branch-only permission for this API.
+**Permission granted.** GitHub’s `Contents: Read & Write` permission allows access to repository files, including source code. It is repository-scoped, not limited to a folder or branch. Branch rules can constrain writes, but storing files on a separate branch does not narrow the app’s permission. See [GitHub’s Contents API documentation](https://docs.github.com/en/rest/repos/contents).
 
-BugDrop does **not** request access to:
+**How BugDrop uses it.** The [file-upload implementation](https://github.com/mean-weasel/bugdrop/blob/511470d91169ac93593ebcc7a0b3e6459ab29df9/src/lib/github.ts) stores screenshots in `.bugdrop/screenshots/` and attachments in `.bugdrop/uploads/` on `bugdrop-screenshots`. To create that branch, it reads repository information and the default branch reference. This describes the inspected implementation, not a technical restriction preventing other use of the granted permission.
 
-- Pull requests
-- Actions or workflows
-- Secrets or environment variables
-- Organization settings
-- Collaborators or team membership
-- Any other repository or account data
-
-You can review and revoke the app's access at any time from your GitHub settings under **Applications > Installed GitHub Apps**.
+**Limit access.** Choose **Only select repositories** when installing and select only the feedback destination. Check GitHub’s installation screen for the permissions you are granting. You can change the selected repositories or revoke access at any time under **GitHub Settings > Applications > Installed GitHub Apps**.
 
 ## Data Storage
 

--- a/docs/website/version-pinning.mdx
+++ b/docs/website/version-pinning.mdx
@@ -6,18 +6,20 @@ completes an on-demand release. An exact URL can identify an asset in the curren
 is present in the authoritative `versions.json`, but availability is not guaranteed across later
 releases.
 
-## Default Behavior
+## Recommended Setup
 
-The default script URL always loads the latest version of the widget:
+The installation guide uses the currently available `widget.v1.56.4.js` asset so you can test a specific version before updating:
 
 ```html
 <script
-  src="https://bugdrop.neonwatty.workers.dev/widget.js"
+  src="https://bugdrop.neonwatty.workers.dev/widget.v1.56.4.js"
   data-repo="owner/repo"
 ></script>
 ```
 
-This is fine for development and testing, but for production sites you may want more control over when updates are applied.
+Use the same URL in each example you copy. An exact URL controls which asset you request; it does not guarantee permanent hosting. Confirm availability before deployment and review the limits below before relying on it for long-term reproducibility.
+
+For automatic updates, use `https://bugdrop.neonwatty.workers.dev/widget.js`. That URL follows the current hosted deployment. Major and minor aliases offer narrower update policies when the corresponding assets are available.
 
 ## Version URL Reference
 
@@ -26,11 +28,11 @@ BugDrop follows [semantic versioning](https://semver.org/) (major.minor.patch). 
 | URL | Example | Update Behavior | Best For |
 |-----|---------|----------------|----------|
 | `/widget.js` | Always latest | Gets all updates automatically | Development, testing |
-| `/widget.v1.js` | Major pin | Gets minor and patch updates (1.x.x) | **Production (recommended)** |
+| `/widget.v1.js` | Major pin | Gets minor and patch updates (1.x.x) | Automatic updates within a major version |
 | `/widget.v1.1.js` | Minor pin | Gets patch updates only (1.1.x) | Cautious production |
-| `/widget.v1.1.0.js` | Exact URL | Identifies a listed current-deployment asset | Inspection and validation |
+| `/widget.v1.1.0.js` | Exact URL | Identifies a listed current-deployment asset | Explicit version selection |
 
-### Major Version Pin (Recommended for Production)
+### Major Version Alias (Automatic Updates)
 
 ```html
 <script
@@ -39,11 +41,11 @@ BugDrop follows [semantic versioning](https://semver.org/) (major.minor.patch). 
 ></script>
 ```
 
-This loads the latest `1.x.x` release. You get bug fixes and new features automatically, but never a breaking change. This is the recommended approach for production sites because:
+This loads the latest `1.x.x` release. You get bug fixes and new features automatically, with the intention of preserving compatibility. Choose this when you want automatic updates within a major version:
 
 - **You get bug fixes automatically** -- No action needed when patches are released
 - **You get new features** -- Minor version updates add functionality without breaking existing behavior
-- **You are protected from breaking changes** -- Major version bumps (which may change the API or behavior) require you to explicitly update the URL
+- **You choose major upgrades** -- Major version bumps require you to explicitly update the URL. Test updates against your integration; version numbering is not a guarantee against regressions
 
 ### Minor Version Pin
 
@@ -106,7 +108,7 @@ Here is a decision guide:
 - You are running a production site
 - You want automatic bug fixes and new features
 - You want protection from breaking API changes
-- **This is the recommended default for most production sites**
+- You will test your integration after updates
 
 ### Use `/widget.v1.1.js` (minor pin) when:
 - You want only bug fixes, not new features
@@ -117,11 +119,9 @@ Here is a decision guide:
 
 - You are inspecting or validating an asset present in the current deployment
 - You have verified its filename and digest against the live `versions.json`
-- You do not depend on that URL remaining available after another release
+- You want to choose when to update, and will verify the URL remains available
 
-Production cutover is blocked until a separately authorized operator phase establishes the boundary
-and proves live N/N+1 behavior. Until then, use a separately controlled archive if your application
-requires cross-release reproducibility.
+For long-term reproducibility, keep an independently controlled copy of an authenticated release asset. An exact URL available today does not by itself establish a cross-release hosting guarantee.
 
 ## Upgrading Versions
 


### PR DESCRIPTION
The installation and FAQ pages said BugDrop could not access source code even though its GitHub App requests Contents read/write permission. This change explains the repository-wide grant, distinguishes it from the upload implementation's use of a dedicated branch, and shows how to limit selected repositories.

Installation examples consistently request v1.56.4, explain the automatic-update alternative and hosting limits, and replace the 30-second promise with a real test-report verification step. No widget runtime or permission settings change.

Validation: documentation sync tests passed; all 22 mirrored website files match this committed source and their recorded digests. The current hosted v1.56.4 asset was downloaded again and matches the website's tested fixture SHA-256. Independent correctness, test, documentation, and simplification reviews found no supported issues. The native `codex review --base origin/main` attempt could not run: the installed CLI is too old for its configured model. The owner explicitly approved proceeding without this unavailable native CLI review after independent review.

This is the canonical source dependency for [website PR #101](https://github.com/mean-weasel/bugdrop-web/pull/101). Land this source correction before releasing the corresponding website documentation sync; refresh its source receipt if merge changes the SHA.
