### PR TITLE
chore: clarify MIT license attribution and package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024
+Copyright (c) 2024-2026 Jeremy Watt and BugDrop contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "bugdrop",
       "version": "0.0.0-development",
+      "license": "MIT",
       "dependencies": {
         "hono": "^4.13.5",
         "html-to-image": "^1.11.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bugdrop",
   "version": "0.0.0-development",
+  "license": "MIT",
   "description": "In-app feedback → GitHub Issues. Screenshots, annotations, the works.",
   "type": "module",
   "main": "./public/widget.js",


### PR DESCRIPTION
Clarifies the MIT copyright notice as Jeremy Watt and BugDrop contributors (2024–2026), and declares `MIT` in package.json and the root package-lock.json entry. The MIT license terms remain unchanged.

Validation: compared both parsed manifests against main to confirm only license metadata changed, verified the license text differs only in its copyright line, checked the diff for whitespace errors, and confirmed LICENSE is included in an npm packaging dry run. Independent correctness, tests, and simplification reviews found no issues.

Review limitation: `codex review --base origin/main` was attempted but the installed CLI rejected its configured gpt-6-astra model as requiring a newer version. Focused reviews completed against main at 17700b36e22939d3c593668a75cc227f9bc4f19f.
