### PR TITLE
ci: scope checks for documentation and license metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
       - name: Verify previous full CI succeeded
         id: previous-ci
         if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
@@ -87,8 +92,8 @@ jobs:
         shell: bash
         env:
           PR_ACTION: ${{ github.event.action }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           PR_BEFORE_SHA: ${{ github.event.before }}
         run: |
           scripts/ci-scope.sh \
@@ -99,11 +104,6 @@ jobs:
             "$PR_BEFORE_SHA" \
             "${{ steps.previous-ci.outputs.result }}"
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '22'
-          cache: 'npm'
-
       - name: Install dependencies
         if: steps.scope.outputs.full_ci != 'false'
         run: make install
@@ -112,12 +112,12 @@ jobs:
         if: steps.scope.outputs.full_ci != 'false'
         run: make check
 
-      - name: Check changed documentation formatting
+      - name: Check changed documentation and metadata formatting
         if: steps.scope.outputs.full_ci == 'false'
         shell: bash
         env:
           DIFF_BASE_SHA: ${{ steps.scope.outputs.diff_base }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
         run: |
           format_files=()
           while IFS= read -r -d '' path; do
@@ -129,7 +129,7 @@ jobs:
             printf '%s\0' "${format_files[@]}" |
               xargs -0 npx --yes prettier@3.8.1 --check --ignore-unknown --
           else
-            echo 'No remaining documentation files require formatting.'
+            echo 'No remaining documentation or metadata files require formatting.'
           fi
 
   # Unit tests and build
@@ -139,7 +139,7 @@ jobs:
     needs: check
     permissions:
       contents: read
-    # Keep the required check visible as skipped for docs-only pull requests.
+    # Keep the required check visible as skipped for docs/metadata-only changes.
     if: needs.check.outputs.full_ci != 'false'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -216,9 +216,9 @@ jobs:
     steps:
       # These no-op matrix jobs preserve the two exact required check names. A job-level
       # condition is evaluated before matrix expansion and would collapse them into one.
-      - name: Skip expensive E2E for documentation-only changes
+      - name: Skip expensive E2E for documentation or metadata changes
         if: needs.check.outputs.full_ci == 'false'
-        run: echo 'Documentation-only change; required E2E context satisfied without browser tests.'
+        run: echo 'Documentation or license metadata change; required E2E context satisfied without browser tests.'
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: needs.check.outputs.full_ci != 'false'
@@ -340,7 +340,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [check, test, e2e, radix-e2e]
-    if: github.event_name == 'merge_group'
+    if: >-
+      ${{ always() && github.event_name == 'merge_group' &&
+          needs.check.result == 'success' &&
+          (needs.check.outputs.full_ci == 'false' ||
+           (needs.test.result == 'success' && needs.e2e.result == 'success' &&
+            needs.radix-e2e.result == 'success')) }}
     permissions:
       contents: read
     concurrency:
@@ -348,23 +353,32 @@ jobs:
       cancel-in-progress: false
       queue: max
     steps:
+      - name: Skip preview for documentation or metadata changes
+        if: needs.check.outputs.full_ci == 'false'
+        run: echo 'No runtime changes; preview deployment and live tests are unnecessary.'
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.check.outputs.full_ci != 'false'
         with:
           fetch-depth: 0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: needs.check.outputs.full_ci != 'false'
         with:
           node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
+        if: needs.check.outputs.full_ci != 'false'
         run: make install
 
       - name: Get Playwright version
+        if: needs.check.outputs.full_ci != 'false'
         id: pw-version
         run: echo "version=$(npx playwright --version | awk '{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
+        if: needs.check.outputs.full_ci != 'false'
         id: pw-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -373,15 +387,16 @@ jobs:
 
       - name: Install Playwright browsers
         timeout-minutes: 10
-        if: steps.pw-cache.outputs.cache-hit != 'true'
+        if: needs.check.outputs.full_ci != 'false' && steps.pw-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Install Playwright system deps
         timeout-minutes: 10
-        if: steps.pw-cache.outputs.cache-hit == 'true'
+        if: needs.check.outputs.full_ci != 'false' && steps.pw-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium firefox webkit
 
       - name: Record canary identity
+        if: needs.check.outputs.full_ci != 'false'
         shell: bash
         run: |
           echo "BUGDROP_CANARY_MARKER=bugdrop-ci-canary:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${GITHUB_SHA}" >> "$GITHUB_ENV"
@@ -395,6 +410,7 @@ jobs:
           echo "PLAYWRIGHT_BASE_URL=https://bugdrop-widget-test-git-preview-jermwatts-projects.vercel.app" >> "$GITHUB_ENV"
 
       - name: Preflight stale canary cleanup
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           node scripts/github-issue-canary.mjs preflight
           --profile preview
@@ -404,6 +420,7 @@ jobs:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 
       - name: Build classic fixed-controller preview widget
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           CLASSIC_OUTPUT="$RUNNER_TEMP/classic-preview-widget"
           node scripts/build-widget.js \
@@ -414,9 +431,11 @@ jobs:
             --default-flow-runtime fixed
 
       - name: Build normal flow-controller preview widget and application
+        if: needs.check.outputs.full_ci != 'false'
         run: BUGDROP_BUILD_MODE=development BUGDROP_DEVELOPMENT_ID="merge-group-${GITHUB_SHA}-candidate" make build-all
 
       - name: Validate and record dual-controller preview identities
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           cp "$RUNNER_TEMP/classic-preview-widget/widget.js" public/widget.classic.js
           CANDIDATE_SHA256=$(shasum -a 256 public/widget.js | awk '{print $1}')
@@ -461,12 +480,14 @@ jobs:
           echo "EXPECTED_CLASSIC_WIDGET_SHA256=$CLASSIC_SHA256" >> "$GITHUB_ENV"
 
       - name: Deploy to preview
+        if: needs.check.outputs.full_ci != 'false'
         run: npx wrangler deploy --env preview --var "BUILD_SHA:$GITHUB_SHA"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Wait for exact preview Worker
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           WORKER_URL="https://bugdrop-preview.neonwatty.workers.dev/api/health"
           echo "Polling preview health for the expected environment and build SHA..."
@@ -485,6 +506,7 @@ jobs:
           exit 1
 
       - name: Wait for exact preview widget asset
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           WIDGET_URL="$EXPECTED_WIDGET_ORIGIN/widget.js"
           CANDIDATE_PATH="$EXACT_WIDGET_FIXTURE_PATH.candidate"
@@ -509,6 +531,7 @@ jobs:
           exit 1
 
       - name: Wait for exact classic preview widget asset
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           WIDGET_URL="$EXPECTED_WIDGET_ORIGIN/widget.classic.js"
           CANDIDATE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH.candidate"
@@ -533,6 +556,7 @@ jobs:
           exit 1
 
       - name: Verify fixed preview venue
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           BYPASS_ARGS=()
           if [ -n "$VERCEL_AUTOMATION_BYPASS_SECRET" ]; then
@@ -547,6 +571,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run candidate legacy and default live E2E tests
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_WIDGET_SHA256"
@@ -557,6 +582,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run classic legacy and default live E2E tests
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
@@ -567,6 +593,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Require identical candidate and classic legacy outcomes
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           node --input-type=module <<'NODE'
           import fs from 'node:fs';
@@ -627,6 +654,7 @@ jobs:
           NODE
 
       - name: Run composable FlowConfig live E2E tests
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_WIDGET_SHA256"
@@ -635,6 +663,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run candidate live Radix E2E tests
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_WIDGET_SHA256"
@@ -643,6 +672,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run classic live Radix E2E tests
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
@@ -651,6 +681,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run candidate Chromium live cross-browser smoke
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_WIDGET_SHA256"
@@ -659,6 +690,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run classic Chromium live cross-browser smoke
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
@@ -667,6 +699,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run candidate Firefox live cross-browser smoke
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_WIDGET_SHA256"
@@ -675,6 +708,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run classic Firefox live cross-browser smoke
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
@@ -683,6 +717,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run candidate WebKit live cross-browser smoke
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_WIDGET_SHA256"
@@ -691,6 +726,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run classic WebKit live cross-browser smoke
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           EXACT_WIDGET_FIXTURE_PATH="$EXACT_CLASSIC_WIDGET_FIXTURE_PATH"
           EXPECTED_WIDGET_SHA256="$EXPECTED_CLASSIC_WIDGET_SHA256"
@@ -699,6 +735,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Run one structured real-Issue canary
+        if: needs.check.outputs.full_ci != 'false'
         run: |
           mkdir -p "$(dirname "$BUGDROP_CANARY_ATTEMPT_FILE")"
           : > "$BUGDROP_CANARY_ATTEMPT_FILE"
@@ -709,6 +746,7 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Verify canary Issue independently
+        if: needs.check.outputs.full_ci != 'false'
         run: >-
           node scripts/github-issue-canary.mjs verify
           --profile preview
@@ -720,7 +758,7 @@ jobs:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 
       - name: Cleanup current canary marker
-        if: always()
+        if: always() && needs.check.outputs.full_ci != 'false'
         run: |
           if [ ! -f "$BUGDROP_CANARY_ATTEMPT_FILE" ]; then
             echo 'The Issue canary never started; no current marker can exist.'
@@ -734,7 +772,7 @@ jobs:
           BUGDROP_CANARY_GITHUB_TOKEN: ${{ secrets.BUGDROP_CANARY_GITHUB_TOKEN }}
 
       - name: Final reserved-prefix sweep
-        if: always()
+        if: always() && needs.check.outputs.full_ci != 'false'
         run: >-
           node scripts/github-issue-canary.mjs sweep
           --profile preview
@@ -745,7 +783,7 @@ jobs:
 
       - name: Upload preview failure report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: failure()
+        if: failure() && needs.check.outputs.full_ci != 'false'
         with:
           name: playwright-preview-critical-report
           path: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,8 +27,19 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Determine analysis scope
+        id: scope
+        shell: bash
+        env:
+          SCOPE_EVENT: ${{ github.event_name }}
+          SCOPE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          SCOPE_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: scripts/ci-scope.sh "$SCOPE_EVENT" opened "$SCOPE_BASE" "$SCOPE_HEAD" '' false
 
       - name: Initialize CodeQL
+        if: steps.scope.outputs.full_ci != 'false'
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
@@ -36,6 +47,7 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Analyze with CodeQL
+        if: steps.scope.outputs.full_ci != 'false'
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,8 +18,19 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Determine analysis scope
+        id: scope
+        shell: bash
+        env:
+          SCOPE_EVENT: ${{ github.event_name }}
+          SCOPE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          SCOPE_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: scripts/ci-scope.sh "$SCOPE_EVENT" opened "$SCOPE_BASE" "$SCOPE_HEAD" '' false
 
       - name: Review dependency changes
+        if: steps.scope.outputs.dependency_review != 'false'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ check-security-analysis-workflows:
 
 check-ci-scope:
 	bash test/ci-scope.test.sh
+	node test/ci-scope-workflow.test.mjs
 
 check-ci-workflow:
 	bash test/ci-workflow-contract.test.sh

--- a/docs/ci-scoping.md
+++ b/docs/ci-scoping.md
@@ -1,0 +1,38 @@
+# CI scope
+
+CI keeps its required check names on every pull request and merge-group event.
+It scopes work inside the workflows instead of filtering away required workflows.
+
+| Changes | Checks |
+| --- | --- |
+| Listed root documentation, non-executable documentation under `docs/`, and `LICENSE` | Changed-file formatting |
+| Only `license` in `package.json` and/or `packages[""].license` in `package-lock.json` | JSON comparison and changed-file formatting |
+| Source, tests, browser fixtures, benchmarks, or public assets | Full lint/typecheck/audit, unit/build, browser tests, and CodeQL |
+| Dependencies, package scripts, build configuration, workflows, or unknown paths | Full CI, CodeQL, and dependency review |
+
+The license exception compares committed JSON objects after removing only the
+project license field, preserving object key order because conditional exports are
+order-sensitive. Changes to dependencies, transitive lock entries, scripts,
+exports, versions, or any other field still require full CI. Deleted, malformed,
+new, and non-regular manifests also require full CI. Nested manifests are always
+treated as dependency changes.
+
+Dependency review skips known source/test/asset-only changes. Unknown paths and
+dependency tooling changes retain the scan. CodeQL still runs its weekly full scan;
+pushes to main use the complete push range, and pull requests use their merge base.
+Missing refs, empty diffs, and unsupported events default to full checks.
+
+For a documentation or license-only merge group, the preview job reports a no-op
+success without deploying, downloading browsers, or creating canary Issues. The
+live-preview bridge requires that job to succeed. A group containing any runtime
+change requires all local test jobs to succeed before deployment and live testing.
+
+A documentation/metadata-only follow-up to a source PR may reuse the preceding
+successful full CI suite, as before. Without that proof, only a wholly lightweight
+PR can skip full CI. Non-fast-forward follow-ups default to full CI.
+
+Run `make check-ci-scope check-ci-workflow check-security-analysis-workflows` to
+exercise committed-change fixtures, preview gate states, required context names,
+and security workflow mutation checks. The scope fixtures include license changes
+mixed with dependency changes, lifecycle scripts, malformed/deleted manifests,
+source renames, and merge groups containing runtime changes.

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
     "src/widget/index.ts",
     "src/widget/public-api.d.ts",
     "scripts/build-widget.js",
+    "scripts/ci-license-only.mjs",
     "scripts/github-issue-canary.mjs",
     "scripts/release/plan.mjs",
     "scripts/verify-legacy-compat.mjs"

--- a/scripts/check-security-analysis-workflows.mjs
+++ b/scripts/check-security-analysis-workflows.mjs
@@ -12,9 +12,15 @@ const checkEqual = (location, actual, expected) => {
   }
 };
 
-const checkBlocking = (location, node) => {
+const checkBlocking = (location, node, scoped = false) => {
+  if (scoped)
+    checkEqual(
+      `${location}: scope condition`,
+      node?.if,
+      `steps.scope.outputs.${scoped} != 'false'`
+    );
   for (const key of ['if', 'continue-on-error']) {
-    if (node && Object.hasOwn(node, key)) {
+    if (node && Object.hasOwn(node, key) && !(scoped && key === 'if')) {
       failures.push(`${location}: must not define ${key}`);
     }
   }
@@ -47,8 +53,8 @@ const codeqlCheckout = codeqlSteps.find(step => step.name === 'Checkout reposito
 const codeqlInit = codeqlSteps.find(step => step.name === 'Initialize CodeQL');
 const codeqlAnalyze = codeqlSteps.find(step => step.name === 'Analyze with CodeQL');
 checkBlocking('codeql.yml: checkout step', codeqlCheckout);
-checkBlocking('codeql.yml: init step', codeqlInit);
-checkBlocking('codeql.yml: analyze step', codeqlAnalyze);
+checkBlocking('codeql.yml: init step', codeqlInit, 'full_ci');
+checkBlocking('codeql.yml: analyze step', codeqlAnalyze, 'full_ci');
 checkEqual(
   'codeql.yml: checkout action',
   codeqlCheckout?.uses,
@@ -56,6 +62,7 @@ checkEqual(
 );
 checkEqual('codeql.yml: checkout configuration', codeqlCheckout?.with, {
   'persist-credentials': false,
+  'fetch-depth': 0,
 });
 checkEqual(
   'codeql.yml: init action',
@@ -100,7 +107,7 @@ const dependencySteps = dependencyReview.jobs?.['dependency-review']?.steps ?? [
 const dependencyCheckout = dependencySteps.find(step => step.name === 'Checkout repository');
 const dependencyScan = dependencySteps.find(step => step.name === 'Review dependency changes');
 checkBlocking('dependency-review.yml: checkout step', dependencyCheckout);
-checkBlocking('dependency-review.yml: review step', dependencyScan);
+checkBlocking('dependency-review.yml: review step', dependencyScan, 'dependency_review');
 checkEqual(
   'dependency-review.yml: checkout action',
   dependencyCheckout?.uses,
@@ -108,6 +115,7 @@ checkEqual(
 );
 checkEqual('dependency-review.yml: checkout configuration', dependencyCheckout?.with, {
   'persist-credentials': false,
+  'fetch-depth': 0,
 });
 checkEqual(
   'dependency-review.yml: review action',
@@ -121,6 +129,27 @@ checkEqual('dependency-review.yml: review configuration', dependencyScan?.with, 
   'show-openssf-scorecard': false,
   'show-patched-versions': true,
 });
+
+for (const [name, steps] of [
+  ['codeql.yml', codeqlSteps],
+  ['dependency-review.yml', dependencySteps],
+]) {
+  checkEqual(
+    `${name}: scope step`,
+    steps.find(step => step.id === 'scope'),
+    {
+      name: 'Determine analysis scope',
+      id: 'scope',
+      shell: 'bash',
+      env: {
+        SCOPE_EVENT: '${{ github.event_name }}',
+        SCOPE_BASE: '${{ github.event.pull_request.base.sha || github.event.before }}',
+        SCOPE_HEAD: '${{ github.event.pull_request.head.sha || github.sha }}',
+      },
+      run: `scripts/ci-scope.sh "$SCOPE_EVENT" opened "$SCOPE_BASE" "$SCOPE_HEAD" '' false`,
+    }
+  );
+}
 
 if (failures.length > 0) {
   console.error(failures.join('\n'));

--- a/scripts/ci-license-only.mjs
+++ b/scripts/ci-license-only.mjs
@@ -1,0 +1,22 @@
+// Compare committed objects, never execute a package manifest or lifecycle hook.
+import { execFileSync } from 'node:child_process';
+
+const [base, head, path] = process.argv.slice(2);
+try {
+  const read = ref => {
+    const entry = execFileSync('git', ['ls-tree', ref, '--', path], { encoding: 'utf8' });
+    if (!entry.startsWith('100644 blob ')) throw new Error('Expected a regular manifest');
+    const value = JSON.parse(execFileSync('git', ['show', `${ref}:${path}`], { encoding: 'utf8' }));
+    const metadata = path === 'package.json' ? value : value.packages[''];
+    if (Object.hasOwn(metadata, 'license') && typeof metadata.license !== 'string') {
+      throw new Error('Expected a string license');
+    }
+    delete metadata.license;
+    return value;
+  };
+  // Conditional exports use object key order to select a matching entry.
+  process.exitCode = JSON.stringify(read(base)) === JSON.stringify(read(head)) ? 0 : 1;
+} catch {
+  // Missing, deleted, malformed, or unsupported manifests require full CI.
+  process.exitCode = 1;
+}

--- a/scripts/ci-scope.sh
+++ b/scripts/ci-scope.sh
@@ -9,7 +9,10 @@ head_sha=${4:-}
 before_sha=${5:-}
 previous_ci_passed=${6:-false}
 
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
 full_ci=true
+dependency_review=true
 diff_base=''
 reason="${event_name} events always run full CI"
 
@@ -17,11 +20,17 @@ commit_exists() {
   [[ -n "$1" ]] && git cat-file -e "$1^{commit}" 2>/dev/null
 }
 
-if [[ "$event_name" == 'pull_request' ]]; then
+if [[ "$event_name" == 'pull_request' || "$event_name" == 'merge_group' || "$event_name" == 'push' ]]; then
   if ! commit_exists "$base_sha" || ! commit_exists "$head_sha"; then
     reason='pull request refs are unavailable; running full CI fail-safe'
   else
-    if [[ "$action" == 'synchronize' ]]; then
+    if [[ "$event_name" != 'pull_request' ]]; then
+      if git merge-base --is-ancestor "$base_sha" "$head_sha"; then
+        diff_base=$base_sha
+      else
+        reason='base is not an ancestor; running full CI fail-safe'
+      fi
+    elif [[ "$action" == 'synchronize' ]]; then
       if ! commit_exists "$before_sha" || ! git merge-base --is-ancestor "$before_sha" "$head_sha"; then
         reason='push delta is unavailable or non-fast-forward; running full CI fail-safe'
       else
@@ -44,23 +53,48 @@ if [[ "$event_name" == 'pull_request' ]]; then
         reason='no changed files were detected; running full CI fail-safe'
       else
         full_ci=false
-        reason='the latest change contains documentation only'
+        dependency_review=false
+        reason='the latest change contains documentation or license metadata only'
 
         for path in "${changed_files[@]}"; do
           case "$path" in
-            AGENTS.md | CHANGELOG.md | CLAUDE.md | CONTRIBUTING.md | LICENSE | PRIVACY.md | README.md | SECURITY.md | SELF_HOSTING.md | TERMS.md | docs/*)
+            AGENTS.md | CHANGELOG.md | CLAUDE.md | CONTRIBUTING.md | LICENSE | PRIVACY.md | README.md | SECURITY.md | SELF_HOSTING.md | TERMS.md)
+              ;;
+            package.json | package-lock.json)
+              if ! node "$script_dir/ci-license-only.mjs" "$diff_base" "$head_sha" "$path"; then
+                full_ci=true
+                reason="${path} changes more than license metadata"
+                dependency_review=true
+              fi
+              ;;
+            */package.json | */package-lock.json | */npm-shrinkwrap.json | */yarn.lock | */pnpm-lock.yaml)
+              full_ci=true
+              dependency_review=true
+              reason="${path} may change dependencies"
+              ;;
+            docs/*.md | docs/*.mdx | docs/*.txt | docs/*.yaml | docs/*.yml | docs/*.json | docs/*.png | docs/*.jpg | docs/*.svg | docs/*.webp)
+              ;;
+            src/* | test/* | e2e/* | benchmarks/* | public/*)
+              full_ci=true
+              reason="${path} requires runtime checks"
               ;;
             *)
+              dependency_review=true
               full_ci=true
               reason="${path} requires full CI"
-              break
               ;;
           esac
         done
 
         if [[ "$action" == 'synchronize' && "$full_ci" == 'false' && "$previous_ci_passed" != 'true' ]]; then
-          full_ci=true
-          reason='previous full CI is missing or unsuccessful; running full CI fail-safe'
+          aggregate_base=$(git merge-base "$base_sha" "$head_sha")
+          if GITHUB_OUTPUT= "$script_dir/ci-scope.sh" pull_request opened "$base_sha" "$head_sha" '' false | grep -x 'full_ci=false' >/dev/null; then
+            diff_base=$aggregate_base
+          else
+            full_ci=true
+            dependency_review=true
+            reason='previous full CI is missing or unsuccessful; running full CI fail-safe'
+          fi
         fi
       fi
     fi
@@ -68,10 +102,12 @@ if [[ "$event_name" == 'pull_request' ]]; then
 fi
 
 echo "full_ci=${full_ci}"
+echo "dependency_review=${dependency_review}"
 echo "diff_base=${diff_base}"
 echo "CI scope: ${reason}"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "full_ci=${full_ci}" >> "$GITHUB_OUTPUT"
+  echo "dependency_review=${dependency_review}" >> "$GITHUB_OUTPUT"
   echo "diff_base=${diff_base}" >> "$GITHUB_OUTPUT"
 fi

--- a/test/ci-scope-workflow.test.mjs
+++ b/test/ci-scope-workflow.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { parse } from 'yaml';
+
+const workflow = parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
+const preview = workflow.jobs['deploy-preview'];
+const condition = preview.if.replace(/^\$\{\{\s*|\s*\}\}$/g, '');
+// Evaluate the actual workflow expression across success, failure, skip and cancellation.
+const permitsPreview = new Function(
+  'always',
+  'github',
+  'needs',
+  `return (${condition.replaceAll('needs.radix-e2e', "needs['radix-e2e']")});`
+);
+for (const event of ['pull_request', 'merge_group']) {
+  for (const full of ['true', 'false', undefined]) {
+    for (const check of ['success', 'failure', 'skipped', 'cancelled']) {
+      for (const test of ['success', 'failure', 'skipped', 'cancelled']) {
+        for (const e2e of ['success', 'failure', 'skipped', 'cancelled']) {
+          for (const radix of ['success', 'failure', 'skipped', 'cancelled']) {
+            const expected =
+              event === 'merge_group' &&
+              check === 'success' &&
+              (full === 'false' || [test, e2e, radix].every(result => result === 'success'));
+            assert.equal(
+              permitsPreview(
+                () => true,
+                { event_name: event },
+                {
+                  check: { result: check, outputs: { full_ci: full } },
+                  test: { result: test },
+                  e2e: { result: e2e },
+                  'radix-e2e': { result: radix },
+                }
+              ),
+              expected
+            );
+          }
+        }
+      }
+    }
+  }
+}
+for (const step of preview.steps.slice(1)) {
+  assert.ok(step.if.includes("needs.check.outputs.full_ci != 'false'"), step.name ?? step.uses);
+}
+assert.equal(preview.steps[0].if, "needs.check.outputs.full_ci == 'false'");
+assert.equal(workflow.jobs['live-preview-tests'].needs[0], 'deploy-preview');
+const checkSteps = workflow.jobs.check.steps;
+assert.ok(
+  checkSteps.findIndex(step => step.uses?.startsWith('actions/setup-node@')) <
+    checkSteps.findIndex(step => step.id === 'scope')
+);
+assert.ok(
+  checkSteps.find(step => step.id === 'scope').env.PR_BASE_SHA.includes('merge_group.base_sha')
+);
+assert.ok(
+  checkSteps.find(step => step.id === 'scope').env.PR_HEAD_SHA.includes('merge_group.head_sha')
+);
+console.log('CI scope workflow gate checks passed (1,536 preview states)');

--- a/test/ci-scope.test.sh
+++ b/test/ci-scope.test.sh
@@ -15,6 +15,8 @@ git -C "$test_repo" config user.email 'ci-scope@example.com'
 mkdir -p "$test_repo/src" "$test_repo/docs"
 printf '# Project\n' > "$test_repo/README.md"
 printf 'export const value = 1;\n' > "$test_repo/src/app.ts"
+printf '{"name":"fixture","dependencies":{"example":"1"}}\n' > "$test_repo/package.json"
+printf '{"packages":{"":{"name":"fixture"},"node_modules/example":{"version":"1","license":"MIT"}}}\n' > "$test_repo/package-lock.json"
 git -C "$test_repo" add .
 git -C "$test_repo" commit --quiet -m 'initial'
 base_sha=$(git -C "$test_repo" rev-parse HEAD)
@@ -109,4 +111,75 @@ assert_scope false pull_request opened "$source_head" "$behind_docs_head" ''
 
 assert_scope true merge_group '' '' '' ''
 
+# The complete licensing PR must be lightweight on open, subsequent pushes, and queue.
+git -C "$test_repo" switch --quiet -c metadata "$base_sha"
+printf 'MIT License\n' > "$test_repo/LICENSE"
+printf '{"name":"fixture","dependencies":{"example":"1"},"license":"MIT"}\n' > "$test_repo/package.json"
+printf '{"packages":{"":{"name":"fixture","license":"MIT"},"node_modules/example":{"version":"1","license":"MIT"}}}\n' > "$test_repo/package-lock.json"
+git -C "$test_repo" add .
+git -C "$test_repo" commit --quiet -m 'license metadata'
+metadata_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope false pull_request opened "$base_sha" "$metadata_head" ''
+assert_scope false pull_request synchronize "$base_sha" "$metadata_head" "$base_sha" false
+assert_scope false merge_group '' "$base_sha" "$metadata_head" ''
+assert_scope false push '' "$base_sha" "$metadata_head" ''
+assert_scope true merge_group '' "$metadata_head" "$base_sha" ''
+assert_scope true schedule '' "$base_sha" "$metadata_head" ''
+assert_scope true pull_request opened invalid "$metadata_head" ''
+
+# A dependency can hide alongside a legitimate license edit; compare all JSON content.
+printf '{"packages":{"":{"name":"fixture","license":"MIT"},"node_modules/example":{"version":"2","license":"MIT"}}}\n' > "$test_repo/package-lock.json"
+git -C "$test_repo" commit --quiet -am 'transitive dependency change'
+dependency_head=$(git -C "$test_repo" rev-parse HEAD)
+assert_scope true pull_request opened "$base_sha" "$dependency_head" ''
+assert_scope true merge_group '' "$base_sha" "$dependency_head" ''
+
+git -C "$test_repo" checkout "$metadata_head" -- package-lock.json
+printf '{"name":"fixture","dependencies":{"example":"1"},"license":"MIT","scripts":{"prepare":"echo side effect"}}\n' > "$test_repo/package.json"
+git -C "$test_repo" commit --quiet -am 'lifecycle change'
+assert_scope true pull_request opened "$base_sha" "$(git -C "$test_repo" rev-parse HEAD)" ''
+
+printf '{invalid json\n' > "$test_repo/package.json"
+git -C "$test_repo" commit --quiet -am 'invalid metadata'
+assert_scope true pull_request opened "$base_sha" "$(git -C "$test_repo" rev-parse HEAD)" ''
+
+git -C "$test_repo" rm --quiet package.json
+git -C "$test_repo" commit --quiet -m 'deleted manifest'
+assert_scope true pull_request opened "$base_sha" "$(git -C "$test_repo" rev-parse HEAD)" ''
+
+# Queue comparisons must include runtime changes from any member of the group.
+assert_scope true merge_group '' "$base_sha" "$docs_head" ''
+assert_dependency_scope() {
+  local expected=$1
+  shift
+  local output
+  output=$(cd "$test_repo" && "$scope_script" "$@")
+  grep -qx "dependency_review=$expected" <<< "$output"
+}
+assert_dependency_scope false pull_request opened "$base_sha" "$source_head" ''
+assert_dependency_scope false pull_request opened "$base_sha" "$metadata_head" ''
+assert_dependency_scope true pull_request opened "$base_sha" "$dependency_head" ''
+assert_dependency_scope true schedule '' '' '' ''
+
+git -C "$test_repo" switch --quiet -c unknown "$base_sha"
+mkdir -p "$test_repo/docs"
+printf 'export const example = 1;\n' > "$test_repo/docs/example.mjs"
+git -C "$test_repo" add .
+git -C "$test_repo" commit --quiet -m 'executable documentation'
+assert_scope true pull_request opened "$base_sha" "$(git -C "$test_repo" rev-parse HEAD)" ''
+
+mkdir -p "$test_repo/test/nested"
+printf '{"dependencies":{"example":"2"}}\n' > "$test_repo/test/nested/package.json"
+git -C "$test_repo" add .
+git -C "$test_repo" commit --quiet -m 'nested manifest'
+assert_dependency_scope true pull_request opened "$base_sha" "$(git -C "$test_repo" rev-parse HEAD)" ''
+# Conditional exports are order-sensitive even when ordinary object equality holds.
+git -C "$test_repo" switch --quiet -c export-order "$base_sha"
+printf '{"name":"fixture","exports":{".":{"types":"./index.d.ts","default":"./index.js"}}}\n' > "$test_repo/package.json"
+git -C "$test_repo" commit --quiet -am 'conditional exports'
+export_base=$(git -C "$test_repo" rev-parse HEAD)
+printf '{"name":"fixture","exports":{".":{"default":"./index.js","types":"./index.d.ts"}},"license":"MIT"}\n' > "$test_repo/package.json"
+git -C "$test_repo" commit --quiet -am 'reordered exports and license'
+assert_scope true pull_request opened "$export_base" "$(git -C "$test_repo" rev-parse HEAD)" ''
+assert_dependency_scope true pull_request opened "$export_base" "$(git -C "$test_repo" rev-parse HEAD)" ''
 echo 'CI scope checks passed'

--- a/test/ci-workflow-contract.test.sh
+++ b/test/ci-workflow-contract.test.sh
@@ -335,7 +335,7 @@ if grep -Eq '^    if:' <<< "$e2e_block"; then
   fail 'the required E2E matrix must not use a job-level condition'
 fi
 grep -Fq 'shard: [1, 2]' <<< "$e2e_block" || fail 'the two-shard E2E matrix changed'
-grep -Fq 'Skip expensive E2E for documentation-only changes' <<< "$e2e_block" ||
+grep -Fq 'Skip expensive E2E for documentation or metadata changes' <<< "$e2e_block" ||
   fail 'the documentation-only E2E context bridge is missing'
 require_literal "$ci_workflow" 'Verify previous full CI succeeded'
 require_literal "$ci_workflow" 'steps.previous-ci.outputs.result'
@@ -351,7 +351,7 @@ bridge=$(job_block "$ci_workflow" live-preview-tests)
 grep -Fq 'name: Deploy Preview' <<< "$critical" || fail 'critical job lost its required name'
 grep -Fq 'needs: [check, test, e2e, radix-e2e]' <<< "$critical" ||
   fail 'preview deployment is not gated by every local job'
-grep -Fq "if: github.event_name == 'merge_group'" <<< "$critical" ||
+grep -Fq "always() && github.event_name == 'merge_group'" <<< "$critical" ||
   fail 'critical job is not merge-group-only'
 grep -Fq 'group: bugdrop-shared-preview' <<< "$critical" || fail 'shared preview lock is missing'
 grep -Fq 'cancel-in-progress: false' <<< "$critical" || fail 'active preview runs may be cancelled'

--- a/test/security-analysis-workflows.test.sh
+++ b/test/security-analysis-workflows.test.sh
@@ -59,9 +59,9 @@ perl -0pi -e 's/(  analyze:\n)/$1    if: false\n/' "$disabled_codeql_job/codeql.
 expect_failure "$disabled_codeql_job" 'codeql.yml: analyze job: must not define if'
 
 disabled_codeql_step=$(make_fixture disabled-codeql-step)
-perl -0pi -e 's/(      - name: Analyze with CodeQL\n)/$1        if: false\n/' \
+perl -0pi -e "s/if: steps.scope.outputs.full_ci != 'false'/if: false/g" \
   "$disabled_codeql_step/codeql.yml"
-expect_failure "$disabled_codeql_step" 'codeql.yml: analyze step: must not define if'
+expect_failure "$disabled_codeql_step" 'codeql.yml: analyze step: scope condition'
 
 warn_only=$(make_fixture warn-only)
 perl -0pi -e 's/(          fail-on-severity: moderate\n)/$1          warn-only: true\n/' \


### PR DESCRIPTION
License-only package metadata currently triggers all runtime checks and merge-queue deployments. This change compares committed manifest contents, allowing only project license fields to differ, and uses lightweight formatting checks for documentation and license changes. All required status names remain present.

Merge groups with only lightweight changes complete the preview job without deploying or running live canaries. Groups containing runtime changes still require successful local tests and the full preview/live section. CodeQL skips lightweight PR/push changes but retains weekly full scans; dependency review skips known source/test/asset-only changes. Dependency, lifecycle, export-order, build, workflow, unknown, malformed, and missing-ref changes retain conservative checks. Existing verified full-CI reuse on documentation follow-ups is preserved.

Validation: `make check` passed, including adversarial committed-change fixtures, 1,536 preview gate states, security workflow mutation tests, action pinning, and permissions checks. The actual #366 diff classifies as `full_ci=false` and `dependency_review=false`. Review found and fixed unguarded browser installation and order-insensitive conditional-export comparison; fresh independent validation confirmed both fixes. Correctness, tests, simplification, silent-failure, contract, and documentation review completed with no remaining findings.

Native `codex review --base origin/main` was attempted but the installed CLI cannot run its configured gpt-6-astra model. Focused reviews used base 17700b36e22939d3c593668a75cc227f9bc4f19f. Live lightweight workflow behavior still needs confirmation after this change lands; this CI-changing PR correctly runs full CI.
