### PR TITLE
feat: add optional server-side repository allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ the live page after testing to restore its original widget and `fetch` implement
 - [Self-Hosting](https://bugdrop.dev/docs/self-hosting)
 - [FAQ](https://bugdrop.dev/docs/faq)
 
+Self-hosters can optionally restrict installation checks and feedback destinations with the
+server-side [`ALLOWED_REPOSITORIES` setting](https://bugdrop.dev/docs/configuration#allowed-repositories).
+It covers legacy and structured submissions; leaving it unset preserves existing behavior.
+
 ## How It Works
 
 ```

--- a/docs/plans/2026-09-10-allowed-repositories.md
+++ b/docs/plans/2026-09-10-allowed-repositories.md
@@ -1,0 +1,257 @@
+# Allowed Repositories Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Add an optional server-side repository allowlist to upstream BugDrop without changing unconfigured deployments.
+
+**Architecture:** A pure shared matcher owns configuration semantics. Installation checks, legacy feedback, and structured feedback each enforce that matcher after their existing validation and before GitHub access. Existing authentication, rate limits, and payload dispatch remain in place.
+
+**Tech Stack:** TypeScript, Hono, Cloudflare Workers, Vitest; existing npm tooling, no new dependencies.
+
+**Spec:** The design and acceptance contract below captures the accepted investigation recommendation. The user subsequently authorized implementation; remote publication and deployment are not part of this execution.
+
+## Context and baseline
+
+- Upstream: `mean-weasel/bugdrop`, `origin/main` at `cbf871bd56a0c805a30f429843943b326dfce6b1`.
+- Fresh worktree: `/tmp/bugdrop-allowed-repositories-plan`.
+- Branch: `codex/plan-allowed-repositories`.
+- Source reference: `mean-weasel/bugdrop-personal` PR #5, head `fe1bf767be9377f81d2a144810c4d967962ad902`, merged as `6dd465d69aa4ee249e03f2d40e67f693f94384d5`. Current fork `42e67e239def9a7ad4e948f3d208bfa021980777` retains the policy.
+- Fork checks passed during investigation: 396 PR-head tests; 410 current-tip tests. Live read-only checks rejected an unlisted repo and accepted the permitted test repo.
+- Upstream has no equivalent policy. Its structured submission dispatch precedes legacy validation; copying only the fork's legacy guard would omit this GitHub write path.
+- Planning baseline: `npm ci --ignore-scripts` completed. `npm test` returned 1 failed / 1596 passed, across 102 files. `test/variantPublicTypes.test.ts:48` failed parsing package command output as JSON (`Unexpected token 'e', "error: cou"...`). Log: `/tmp/bugdrop-allowlist-plan-baseline.log`. Root cause is not established. Resolve or independently explain this before claiming the implementation suite is green; do not silently waive it.
+
+## Global constraints
+
+- Implementation authorized by the subsequent user request, "Lets begin." Publication and deployment remain outside this execution.
+- Preserve existing behavior when the setting is absent, blank, or standalone `*`.
+- No personal repository names, Seatify secrets, private App routing, or active production restriction.
+- No changes to token claim comparison, CORS, quotas, release workflows, widget API, or feedback schemas.
+- No runtime dependencies. Strict TypeScript; use existing formatting conventions.
+- Use `bugdrop.localhost` for local server URLs.
+- Run the repository-required PR review against the actual upstream base before merge. Do not bypass a failed review tool by treating it as a clean result.
+- Review is read-only; simplification requires its own authorized implementation scope.
+
+## Design and acceptance contract
+
+### Chosen approach
+
+Use one matcher with three explicit call sites. This keeps malformed-payload handling and middleware precedence intact while preventing divergence in list parsing.
+
+Alternatives considered:
+
+1. An early shared middleware: fewer call sites, but it would need to duplicate payload validation or change 400/401/429 precedence.
+2. A low-level GitHub-client restriction: covers more calls but confuses request-target policy with webhook, installation inventory, and scheduled maintenance responsibilities, and makes HTTP 403 handling indirect.
+
+Both alternatives are outside this focused port. Future repository-target entry points must use the same matcher before GitHub access.
+
+### Configuration semantics
+
+| Input | Result |
+| --- | --- |
+| `undefined`, `''`, whitespace | Unrestricted |
+| Standalone `*`, including surrounding whitespace | Unrestricted |
+| Comma or newline list | Trim each entry, lowercase, remove empty entries, compare exact full name |
+| Duplicate names | Harmless |
+| `team/*` or `*,team/repo` | No glob expansion; only literal exact membership |
+| Separator-only nonblank value | Deny all |
+| Unknown/malformed entry | Does not expand access; no fallback to unrestricted |
+
+The matcher does not rewrite payloads, GitHub owner/repo arguments, or signed token claims. Case-insensitive policy comparison does not make token claims case-insensitive. Do not introduce a new repository grammar or repair existing malformed-input behavior in this port. Existing validation rejects malformed inputs as before; exact restricted membership also rejects extra segments not present in the list.
+
+### Enforcement and precedence
+
+- `/api/check/:owner/:repo`: guard after forming `fullRepo`, before optional token authentication and installation lookup. Disallowed targets return 403 even if check authentication is enabled.
+- Legacy `/api/feedback`: guard after existing owner/repo validation, before route-level token check and `getInstallationAccess`.
+- Structured `/api/feedback`: guard after successful `validateStructuredFeedback`, before `getInstallationAccess` in `handleStructuredFeedback`.
+- Both submission formats still traverse IP limiter, authentication middleware, and repository limiter first. Missing/invalid tokens may return 401; exhausted quotas may return 429. A valid authenticated denied submission can consume quota. Preserve this behavior explicitly.
+- A reached denial returns exactly `{ error: 'Repository is not allowed' }`, HTTP 403. No installation lookup, token minting, upload, visibility lookup, issue/label write, or successful-feedback accounting may follow it.
+- Health, static assets, public stats, webhook verification, and scheduled inventory are unaffected. This is a request-target policy, not a universal prohibition on every GitHub API operation.
+
+### Files and responsibilities
+
+| File | Work |
+| --- | --- |
+| `src/lib/repository-policy.ts` (new) | Pure matcher |
+| `src/types.ts` | Optional `ALLOWED_REPOSITORIES?: string` binding |
+| `src/routes/api.ts` | Installation and legacy guards |
+| `src/routes/structured-feedback.ts` | Structured guard |
+| `test/repositoryPolicy.test.ts` (new) | Configuration truth table |
+| `test/api.test.ts` | Installation/legacy denial, success, auth and quota behavior |
+| `test/structuredFeedback.test.ts` | Structured denial, success, authenticated adversarial test |
+| `test/repositoryPolicyIntegration.test.ts` (new) | Real Hono route integration with network tripwire |
+| `docs/website/configuration.mdx` | Server setting and examples |
+| `docs/website/security.mdx` | Boundary and response precedence |
+| `README.md` | Short self-hosting note linking to configuration |
+| `wrangler.toml` | Commented examples only in root/preview/production vars blocks |
+
+## Task 1: Matcher and binding contract
+
+**Files:** Create `src/lib/repository-policy.ts`, `test/repositoryPolicy.test.ts`; modify `src/types.ts`.
+
+**Interface produced:** `isRepositoryAllowed(configuredRepositories: string | undefined, repo: string): boolean`.
+
+- [x] Write table-driven tests using this core truth table; include CRLF lists, duplicate entries, and trimmed request names as additional rows.
+
+```ts
+import { expect, it } from 'vitest';
+import { isRepositoryAllowed } from '../src/lib/repository-policy';
+
+it.each([
+  [undefined, 'other/repo', true],
+  ['', 'other/repo', true],
+  [' \n ', 'other/repo', true],
+  [' * ', 'other/repo', true],
+  [' Team/Repo , second/repo\nthird/repo ', 'TEAM/REPO', true],
+  ['team/repo', 'team/repo-extra', false],
+  ['team/repo', 'team/repo/extra', false],
+  ['team/repo', 'team%2Frepo', false],
+  ['team/*', 'team/repo', false],
+  ['*,team/repo', 'other/repo', false],
+  ['*,team/repo', 'team/repo', true],
+  [',\n,', 'team/repo', false],
+  ['invalid-entry', 'team/repo', false],
+] as const)('policy %j for %s => %s', (config, repo, allowed) => {
+  expect(isRepositoryAllowed(config, repo)).toBe(allowed);
+});
+```
+
+- [x] Run `npx vitest run test/repositoryPolicy.test.ts`; confirm failure due to missing helper.
+- [x] Add the optional Env field beside `ALLOWED_ORIGINS` and implement:
+
+```ts
+export function isRepositoryAllowed(
+  configuredRepositories: string | undefined,
+  repo: string
+): boolean {
+  const configured = configuredRepositories?.trim();
+  if (!configured || configured === '*') return true;
+  return configured.split(/[,\n]/)
+    .map(entry => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .includes(repo.trim().toLowerCase());
+}
+```
+
+- [x] Format changed files; rerun helper tests and `npm run typecheck`.
+- [x] Commit the helper/type/tests as `feat: add optional repository policy matcher`.
+
+## Task 2: Enforce all three entry points
+
+**Files:** Modify both route files and their existing tests.
+
+**Consumes:** Task 1 matcher and Env field. **Produces:** the specified 403 denial on each GitHub-reaching request path.
+
+- [x] Add denied check and legacy feedback tests in `test/api.test.ts` using its existing `app`, `mockEnv`, and `validPayload`. Set the list to `approved/repo`; existing `testowner/testrepo` must be denied. Assert exact response and every existing GitHub mock is untouched.
+- [x] Add the equivalent structured test using the existing fixture and env in `test/structuredFeedback.test.ts`. Drive the public API router, not just the structured function.
+
+```ts
+const response = await app.fetch(new Request('http://bugdrop.localhost/feedback', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(validPayload),
+}), { ...env, ALLOWED_REPOSITORIES: 'approved/repo' });
+expect(response.status).toBe(403);
+expect(await response.json()).toEqual({ error: 'Repository is not allowed' });
+expect(mockGetInstallationToken).not.toHaveBeenCalled();
+expect(mockCreateIssue).not.toHaveBeenCalled();
+expect(mockIsRepoPublic).not.toHaveBeenCalled();
+```
+
+In legacy tests use `mockEnv` and also assert `mockUploadScreenshotAsAsset` and `mockUploadAttachmentAsAsset` have no calls. Supply the existing valid screenshot/attachment fixtures so denial covers evidence-bearing requests.
+
+- [x] Run `npx vitest run test/api.test.ts test/structuredFeedback.test.ts` and record failures before implementing guards.
+- [x] Import the matcher into both route modules. Insert this guard at each placement specified in the design, using `fullRepo` for installation checks and `payload.repo` for both submissions:
+
+```ts
+if (!isRepositoryAllowed(c.env.ALLOWED_REPOSITORIES, payload.repo)) {
+  return c.json({ error: 'Repository is not allowed' }, 403);
+}
+```
+
+- [x] Add explicit allowed success for each path using a case-varied configuration entry, retaining the payload's original spelling for GitHub calls and token claims. Preserve existing no-setting success assertions. Check malformed JSON and missing owner/repo still take existing validation paths with auth disabled; structured invalid schema remains 400.
+- [x] Rerun both suites and helper tests; commit as `feat: enforce repository policy on all feedback paths`.
+
+## Task 3: Adversarial authentication and quota proof
+
+**Files:** Existing API/structured tests. **Consumes:** Task 2 guarded routes and existing `createBugDropAuthTokenForTest` export. **Produces:** proof that successful authentication cannot bypass policy, with documented middleware precedence.
+
+- [x] In both suites, create a valid token for the denied fixture repo using the existing signing helper. Use `ENVIRONMENT: 'production'` and a KV stub with `get: vi.fn().mockResolvedValue('0')`, `put: vi.fn().mockResolvedValue(undefined)`, cast via `unknown as KVNamespace` as existing tests do.
+
+```ts
+const secret = 'repository-policy-test-secret-at-least-32-bytes';
+const now = Math.floor(Date.now() / 1000);
+const token = await createBugDropAuthTokenForTest({
+  sub: 'policy-test-user', repo: validPayload.repo,
+  iat: now, exp: now + 300, jti: 'policy-denial-test',
+}, secret);
+```
+
+Submit the valid fixture with this bearer token, `AUTH_TOKEN_SECRET: secret`, `ALLOWED_REPOSITORIES: 'approved/repo'`, and the KV stub. Assert 403 and zero GitHub mocks. Assert repository quota writes occurred: authenticated denial currently follows quota accounting.
+
+- [x] Repeat with no bearer token: expect 401 and no repo quota write. Repeat with KV returning `'50'` only for keys starting `repo:` and `'0'` otherwise: valid-token request returns 429 and zero GitHub calls.
+- [x] Add denied GET with `AUTH_TOKEN_REQUIRED_FOR_CHECK: 'true'` and no token: expect policy 403 before check auth. Add allowed GET with required auth and no token: expect 401.
+- [x] Run the focused suites. Temporarily remove ONLY the structured guard, rerun its valid-token denial test, and require it to fail; restore the guard immediately and rerun. Repeat for the legacy and GET denial tests one guard at a time. Record these mutation results as the strongest bypass proof. Never commit disabled guards.
+- [x] Commit tests as `test: prove repository denial survives authentication and quotas`.
+
+## Task 4: Route integration with a network tripwire
+
+**Files:** Create `test/repositoryPolicyIntegration.test.ts`. **Consumes:** real `src/routes/api.ts`; no GitHub module mocks. **Produces:** deterministic API integration evidence with no external writes.
+
+- [x] Import the real API router into a Hono app mounted at `/api`. Use an Env fixture with placeholder GitHub credentials, `ENVIRONMENT: 'development'`, `ALLOWED_ORIGINS: '*'`, `MAX_SCREENSHOT_SIZE_MB: '5'`, `ASSETS: {} as Fetcher`, and `ALLOWED_REPOSITORIES: 'approved/repo'`.
+- [x] Stub global fetch with a tripwire, restore globals after each case:
+
+```ts
+const network = vi.fn(() => { throw new Error('Unexpected external request'); });
+vi.stubGlobal('fetch', network);
+```
+
+- [x] Exercise `app.request` at `http://bugdrop.localhost/api/check/blocked/repo` and POST both valid legacy and structured payloads to `/api/feedback`, all targeting `blocked/repo`. Use the structured fixture's required fields (`kind`, `schemaVersion`, `variantId`, `submissionId`, `issue`, `metadata`) exactly as in the existing suite. Assert exact 403 body and `expect(network).not.toHaveBeenCalled()` for every case.
+- [x] Include malformed JSON and a health request to verify normal 400/200 behavior with a restrictive list. Do not send allowed requests to a real GitHub client with real credentials.
+- [x] Run `npx vitest run test/repositoryPolicyIntegration.test.ts`; this is the local API integration gate. It uses real routing/client imports without starting a server or requiring deployed secrets.
+- [x] Commit as `test: verify repository policy before external access`.
+
+## Task 5: Operator documentation and release handoff
+
+**Files:** README, configuration/security MDX, commented `wrangler.toml` examples.
+
+- [x] Add a server-configuration subsection with the full semantics table, deployment-wide scope, no widget attribute, 403 body, and authentication/quota precedence. Explain that an allowlist grants no GitHub permissions and replaces neither auth nor CORS. Explain that blank or `*` disables restriction.
+- [x] Add this commented example under each relevant vars block without introducing an active assignment:
+
+```toml
+# Optional exact repository allowlist (unset allows all installed repositories).
+# ALLOWED_REPOSITORIES = "example-org/app,example-org/feedback"
+```
+
+- [x] Explain configuring root, preview, and production environments explicitly rather than assuming vars inheritance. Document listing both names during a transfer and issuing tokens for the actual new repo name; remove the old name after transfer verification.
+- [x] Add a short README note linking the self-hosting setting to configuration documentation. Update security documentation with the three guarded paths and limits. Keep personal identities out of all examples.
+- [x] Format only changed docs/code; run `npm run validate` and `npm run verify:legacy-compat`. Investigate the recorded package-test baseline failure before declaring full verification. Do not change unrelated code merely to make the plan appear green.
+- [x] Verify no active policy was introduced: inspect `git diff -- wrangler.toml` and run `rg -n '^\s*ALLOWED_REPOSITORIES\s*=' wrangler.toml` (expected no matches). Confirm release workflows and credentials are unchanged.
+- [x] Run `git diff --check`; inspect the final diff for all three guard placements, no payload mutation, no fork-specific behavior, and no accidental production enablement.
+- [x] Commit documentation as `docs: explain optional repository restrictions`.
+- [ ] For a later authorized PR, run `codex-pr-review-toolkit:review-pull-request` against the then-current resolved upstream base, including fresh validation of candidates. The investigation's native review failed due to CLI/model incompatibility; ensure a supported native reviewer or report the unresolved review limitation explicitly. Follow current repository CI and merge requirements.
+
+## Acceptance checklist and rollout
+
+- [x] Truth table implemented and tested; missing configuration preserves existing clients.
+- [x] All three entry points deny before GitHub access, including authenticated structured feedback.
+- [x] Zero upload/issue/lookup calls on denial; network tripwire passes.
+- [x] Existing invalid-input handling and auth/quota precedence preserved.
+- [x] Default/preview/production configuration remains unrestricted unless an operator opts in.
+- [x] Documentation matches executable behavior; no personal-only functionality ported.
+- [x] Guard-removal mutation tests fail and restored code passes; retain command receipts.
+- [x] Full validation is green or a concrete unresolved baseline blocker is reported without a completion claim.
+
+The implementation should ship as one focused upstream PR containing the capability only. Production activation is a separate operator action: inventory intended repositories, configure the appropriate environment, deploy through the existing release process, and check allowed/denied targets. Any live issue-writing canary requires explicit authorization. Roll back an activation by restoring the prior setting/deployment through that process; removing the setting restores unrestricted compatibility behavior. No activation or deployment is part of this plan-writing task.
+
+## Execution receipt — 2026-09-10
+
+Implemented locally; no remote publication, merge, production activation, or deployment.
+
+- Tests for route enforcement and authentication/quota precedence were consolidated in `test/repositoryPolicyRoutes.test.ts` rather than extending the large existing API/structured suites. Existing suites were also run unchanged.
+- Matcher tests first failed on the missing module; six route-denial tests then failed on absent guards (26 other route cases passed). After adding the guards, all four helper/new-route/existing-route suites passed (172 tests).
+- Each guard was removed independently and restored in a `finally` block. GET, legacy, and structured suites each failed under the corresponding mutation. Restored policy suites passed 52 tests, including five real-client integration cases asserting no external requests. Logs: `/tmp/allowlist-mutation-0.log`, `/tmp/allowlist-mutation-1.log`, `/tmp/allowlist-mutation-2.log`, `/tmp/allowlist-final-focused.log`.
+- Full verification: `HUSKY=0 npm_config_foreground_scripts=false npm run validate` passed lint, formatting, both TypeScript configurations, and 1,649 tests across 105 files. Log: `/tmp/allowlist-validate.log`. `npm run verify:legacy-compat` verified both immutable fixtures and the gzip budget.
+- Baseline package failure explained and avoided without a source change: concurrent package tests invoke npm/pacote prepare scripts despite `--ignore-scripts`; Husky's shared Git config write can encounter a lock and print non-JSON output into `npm pack --json`. An isolated locked fixture reproduced the failure. Disabling Husky and foreground lifecycle output for validation avoided both the write and stdout contamination; the two package suites independently passed 35 tests.
+- Independent read-only implementation review found no high-confidence issues. This is a local implementation review, not the required pre-merge PR toolkit review. That later gate remains unchecked above.
+- `git diff --check` passed; direct inspection and a no-match search for active `ALLOWED_REPOSITORIES` assignments confirmed only comments were added to Wrangler configuration.
+- Authentication/quota tests were committed with the route implementation rather than as a separate tests-only commit; behavior and coverage are unchanged from the plan.

--- a/docs/website/configuration.mdx
+++ b/docs/website/configuration.mdx
@@ -325,6 +325,69 @@ This attribute only adds the client-side header. Your self-hosted worker must al
 | Some categories take effect but others don't | Unknown category keys (anything other than `bug`/`feature`/`question`) are dropped with a warning. Check spelling. |
 | GitHub returns a 422 | A configured label doesn't exist in the repo. BugDrop retries with default labels automatically; the issue still gets created and the rejection is recorded in the body. |
 
+## Server Configuration
+
+### Allowed repositories
+
+Self-hosted Workers can set `ALLOWED_REPOSITORIES` to restrict the repositories accepted by
+installation checks and both legacy and structured feedback submissions. This is a deployment-wide
+server setting: it applies to every client in that Worker environment, including direct API calls.
+There is no widget attribute for it.
+
+| Setting | Behavior |
+| --- | --- |
+| Unset, empty, or whitespace-only | No repository restriction; existing GitHub App access requirements still apply |
+| Standalone `*`, with optional surrounding whitespace | No repository restriction |
+| Comma- or newline-separated `owner/repo` names | Trim entries, discard empty entries, and match exact full names case-insensitively; CRLF is supported |
+| Duplicate names | Harmless; same membership result |
+| `example-org/*` | Literal entry, with no glob expansion |
+| `*,example-org/app` | Only exact listed names match; `*` does not allow other repositories |
+| Nonblank separators only, such as `,` | Deny every repository |
+| Unknown or malformed entries | No expansion or fallback to unrestricted access; other exact entries can still match |
+
+The requested name is trimmed and compared case-insensitively for policy membership only. The
+setting does not rewrite submitted repository names, GitHub arguments, or signed token claims.
+For example, `example-org/app` does not match `example-org/app-extra` or `example-org/app/extra`.
+Existing request validation still applies.
+
+Configure each environment explicitly in `wrangler.toml`; Wrangler environment vars do not inherit
+from the root vars block. These examples are commented so they do not enable a restriction:
+
+```toml
+[vars]
+# ALLOWED_REPOSITORIES = "example-org/app,example-org/feedback"
+
+[env.preview.vars]
+# ALLOWED_REPOSITORIES = "example-org/app,example-org/feedback"
+
+[env.production.vars]
+# ALLOWED_REPOSITORIES = "example-org/app,example-org/feedback"
+```
+
+Add the setting to the existing vars block for each intended environment, then deploy through your
+normal release process. Removing it, setting it blank, or using standalone `*` disables the
+restriction. Listing a repository grants no GitHub permissions: the App must still be installed with
+the required access. The list replaces neither authentication nor CORS configuration.
+
+When a request reaches the policy check with a disallowed target, it returns HTTP `403`:
+
+```json
+{ "error": "Repository is not allowed" }
+```
+
+For feedback submissions, the IP limiter, authentication middleware, and repository limiter run
+before the policy. Missing or invalid tokens can return `401`, and exhausted quotas can return
+`429`, before repository denial. An authenticated denied submission can consume quota. Existing
+payload validation also runs before the policy. For `GET /api/check/:owner/:repo`, repository denial
+runs before optional check authentication, so a disallowed target returns `403` even when
+`AUTH_TOKEN_REQUIRED_FOR_CHECK` is enabled and no token is supplied. A valid token cannot override
+a repository denial. See [repository policy security boundaries](/docs/security#repository-policy).
+
+Before a repository transfer or rename, list both the old and new full names. Update clients and
+issue tokens for the actual new repository name; token claim comparison remains exact even though
+the allowlist comparison is case-insensitive. Verify GitHub App access and allowed/denied behavior
+after the transfer, then remove the old name.
+
 ## Automatic System Information
 
 Every feedback submission automatically captures the following system information, with no configuration required:

--- a/docs/website/security.mdx
+++ b/docs/website/security.mdx
@@ -234,6 +234,27 @@ This protects the feedback endpoint from direct API calls that bypass browser CO
 
 If installation status is also sensitive, set `AUTH_TOKEN_REQUIRED_FOR_CHECK = "true"` so the widget's `/check/:owner/:repo` request requires the same token.
 
+### Repository policy
+
+Self-hosted Workers can restrict request targets with
+[`ALLOWED_REPOSITORIES`](/docs/configuration#allowed-repositories). The server enforces it on
+`GET /api/check/:owner/:repo`, legacy `POST /api/feedback`, and structured `POST /api/feedback`.
+A reached denial returns `403` with `{ "error": "Repository is not allowed" }` before installation
+lookup, token minting, uploads, repository visibility checks, or issue and label writes. It does not
+record successful feedback.
+
+Both feedback formats still pass through the IP limiter, authentication middleware, and repository
+limiter before payload validation and repository policy. These earlier checks can return `401` or
+`429`; an authenticated denied submission can consume quota. Installation checks enforce repository
+policy before optional token authentication, so a denied target returns `403` even without a token
+when check authentication is required. Successful authentication never overrides repository denial.
+
+The setting applies across clients in the configured Worker environment. Unset, blank, or standalone
+`*` keeps the environment unrestricted by this policy. It grants no GitHub App permissions and
+replaces neither host-app authentication nor CORS. Limit the App's installed repositories separately.
+Health, static assets, public stats, webhook verification, and scheduled installation inventory are
+unaffected; this setting does not prohibit every GitHub API operation for unlisted repositories.
+
 ## Reporting Security Issues
 
 If you discover a security vulnerability in BugDrop, report it privately:

--- a/src/lib/repository-policy.ts
+++ b/src/lib/repository-policy.ts
@@ -1,0 +1,14 @@
+/** Optional exact repository boundary; absent, blank, or standalone '*' is unrestricted. */
+export function isRepositoryAllowed(
+  configuredRepositories: string | undefined,
+  repo: string
+): boolean {
+  const configured = configuredRepositories?.trim();
+  if (!configured || configured === '*') return true;
+
+  return configured
+    .split(/[,\n]/)
+    .map(entry => entry.trim().toLowerCase())
+    .filter(Boolean)
+    .includes(repo.trim().toLowerCase());
+}

--- a/src/routes/api.ts
+++ b/src/routes/api.ts
@@ -1,3 +1,4 @@
+import { isRepositoryAllowed } from '../lib/repository-policy';
 import { Hono, type Context, type Next } from 'hono';
 import { cors } from 'hono/cors';
 import type {
@@ -205,6 +206,10 @@ api.get('/check/:owner/:repo', async c => {
   const { owner, repo } = c.req.param();
   const fullRepo = `${owner}/${repo}`;
 
+  if (!isRepositoryAllowed(c.env.ALLOWED_REPOSITORIES, fullRepo)) {
+    return c.json({ error: 'Repository is not allowed' }, 403);
+  }
+
   if (c.env.AUTH_TOKEN_REQUIRED_FOR_CHECK === 'true') {
     const authError = await requireBugDropAuthToken(c, fullRepo);
     if (authError) return authError;
@@ -275,6 +280,10 @@ api.post('/feedback', async c => {
       },
       400
     );
+  }
+
+  if (!isRepositoryAllowed(c.env.ALLOWED_REPOSITORIES, payload.repo)) {
+    return c.json({ error: 'Repository is not allowed' }, 403);
   }
 
   const authError = await requireBugDropAuthToken(c, payload.repo);

--- a/src/routes/structured-feedback.ts
+++ b/src/routes/structured-feedback.ts
@@ -1,3 +1,4 @@
+import { isRepositoryAllowed } from '../lib/repository-policy';
 /* eslint-disable max-lines -- Keep the isolated structured contract out of the legacy route. */
 import type { Context } from 'hono';
 import { GitHubLabelError, createIssue, getInstallationAccess, isRepoPublic } from '../lib/github';
@@ -90,6 +91,9 @@ export async function handleStructuredFeedback(c: StructuredContext, input: unkn
   }
 
   const payload = validation.payload;
+  if (!isRepositoryAllowed(c.env.ALLOWED_REPOSITORIES, payload.repo)) {
+    return c.json({ error: 'Repository is not allowed' }, 403);
+  }
   const [owner, repo] = payload.repo.split('/');
 
   try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface Env {
   ENVIRONMENT: string;
   BUILD_SHA?: string; // Optional deployed source identity for health and feedback responses
   ALLOWED_ORIGINS: string; // Comma-separated list of allowed origins, or "*" for dev
+  ALLOWED_REPOSITORIES?: string; // Optional comma/newline-separated exact owner/repo allowlist
   GITHUB_APP_NAME: string; // Your GitHub App name for install URL
   MAX_SCREENSHOT_SIZE_MB: string; // Max screenshot size in MB (default: 5)
   CATEGORY_LABELS?: string; // Optional JSON category-label mapping keyed by repo or "*"

--- a/test/repositoryPolicy.test.ts
+++ b/test/repositoryPolicy.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from 'vitest';
+import { isRepositoryAllowed } from '../src/lib/repository-policy';
+
+it.each([
+  [undefined, 'other/repo', true],
+  ['', 'other/repo', true],
+  [' \n ', 'other/repo', true],
+  [' * ', 'other/repo', true],
+  [' Team/Repo , second/repo\nthird/repo ', 'TEAM/REPO', true],
+  ['team/repo', 'team/repo-extra', false],
+  ['team/repo', 'team/repo/extra', false],
+  ['team/repo', 'team%2Frepo', false],
+  ['team/*', 'team/repo', false],
+  ['*,team/repo', 'other/repo', false],
+  ['*,team/repo', 'team/repo', true],
+  [',\n,', 'team/repo', false],
+  ['team/repo\r\nother/repo', 'other/repo', true],
+  ['team/repo,team/repo', ' team/repo ', true],
+  ['invalid-entry', 'team/repo', false],
+] as const)('policy %j for %s => %s', (config, repo, allowed) => {
+  expect(isRepositoryAllowed(config, repo)).toBe(allowed);
+});

--- a/test/repositoryPolicyIntegration.test.ts
+++ b/test/repositoryPolicyIntegration.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Hono } from 'hono';
+import api from '../src/routes/api';
+import type { Env } from '../src/types';
+
+// Real API and GitHub client imports: any attempted external request is a failure.
+const app = new Hono<{ Bindings: Env }>().route('/api', api);
+const env: Env = {
+  GITHUB_APP_ID: 'test-app',
+  GITHUB_PRIVATE_KEY: 'test-key',
+  ENVIRONMENT: 'development',
+  ALLOWED_ORIGINS: '*',
+  GITHUB_APP_NAME: 'test-app',
+  MAX_SCREENSHOT_SIZE_MB: '5',
+  ASSETS: {} as Fetcher,
+  ALLOWED_REPOSITORIES: 'approved/repo',
+};
+const network = vi.fn(() => {
+  throw new Error('Unexpected external request');
+});
+const metadata = {
+  url: 'https://example.test/report',
+  userAgent: 'test',
+  viewport: { width: 1024, height: 768 },
+  timestamp: '2026-09-10T12:00:00Z',
+};
+const legacy = { repo: 'blocked/repo', title: 'Report', metadata };
+const structured = {
+  kind: 'bugdrop.variant-submission',
+  schemaVersion: 1,
+  repo: 'blocked/repo',
+  variantId: 'report',
+  submissionId: 'policy-integration-1',
+  issue: {
+    title: 'Report',
+    classification: 'bug',
+    sections: [{ heading: 'Problem', value: 'Broken' }],
+  },
+  metadata,
+};
+
+beforeEach(() => {
+  network.mockClear();
+  vi.stubGlobal('fetch', network);
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe('repository policy real-client integration', () => {
+  it('rejects an installation check before external access', async () => {
+    const response = await app.request('http://bugdrop.localhost/api/check/blocked/repo', {}, env);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'Repository is not allowed' });
+    expect(network).not.toHaveBeenCalled();
+  });
+  it.each([
+    ['legacy', legacy],
+    ['structured', structured],
+  ])('rejects %s feedback before external access', async (_, payload) => {
+    const response = await app.request(
+      'http://bugdrop.localhost/api/feedback',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      },
+      env
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'Repository is not allowed' });
+    expect(network).not.toHaveBeenCalled();
+  });
+  it('keeps invalid JSON on the validation path', async () => {
+    const response = await app.request(
+      'http://bugdrop.localhost/api/feedback',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{',
+      },
+      env
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'Invalid JSON' });
+    expect(network).not.toHaveBeenCalled();
+  });
+  it('does not restrict health checks', async () => {
+    const response = await app.request('http://bugdrop.localhost/api/health', {}, env);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ status: 'ok' });
+    expect(network).not.toHaveBeenCalled();
+  });
+});

--- a/test/repositoryPolicyRoutes.test.ts
+++ b/test/repositoryPolicyRoutes.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import api from '../src/routes/api';
+import { createBugDropAuthTokenForTest } from '../src/lib/authToken';
+import type { Env } from '../src/types';
+
+const github = vi.hoisted(() => ({
+  getInstallationToken: vi.fn(),
+  getInstallationAccess: vi.fn(),
+  createIssue: vi.fn(),
+  uploadScreenshotAsAsset: vi.fn(),
+  uploadAttachmentAsAsset: vi.fn(),
+  isRepoPublic: vi.fn(),
+}));
+vi.mock('../src/lib/github', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/lib/github')>()),
+  ...github,
+}));
+
+const env: Env = {
+  GITHUB_APP_ID: 'test-app',
+  GITHUB_PRIVATE_KEY: 'test-key',
+  ENVIRONMENT: 'test',
+  ALLOWED_ORIGINS: '*',
+  GITHUB_APP_NAME: 'test-app',
+  MAX_SCREENSHOT_SIZE_MB: '5',
+  ASSETS: {} as Fetcher,
+};
+const metadata = {
+  url: 'https://example.test/report',
+  userAgent: 'test',
+  viewport: { width: 1024, height: 768 },
+  timestamp: '2026-09-10T12:00:00Z',
+};
+const legacy = {
+  repo: 'testowner/testrepo',
+  title: 'A report',
+  metadata,
+  screenshot:
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  attachments: [
+    {
+      name: 'report.pdf',
+      type: 'application/pdf',
+      size: 8,
+      dataUrl: 'data:application/pdf;base64,JVBERi0xLjQ=',
+    },
+  ],
+};
+const structured = {
+  kind: 'bugdrop.variant-submission',
+  schemaVersion: 1,
+  repo: 'testowner/testrepo',
+  variantId: 'report',
+  submissionId: 'policy-report-1',
+  issue: {
+    title: 'A report',
+    classification: 'bug',
+    sections: [{ heading: 'Problem', value: 'Broken' }],
+  },
+  metadata,
+};
+const secret = 'repository-policy-test-secret-at-least-32-bytes';
+function submit(payload: unknown, bindings: Env, token?: string) {
+  return api.request(
+    'http://bugdrop.localhost/feedback',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(payload),
+    },
+    bindings
+  );
+}
+function expectNoGitHub() {
+  for (const call of Object.values(github)) expect(call).not.toHaveBeenCalled();
+}
+async function signedToken(repo: string) {
+  const now = Math.floor(Date.now() / 1000);
+  return createBugDropAuthTokenForTest(
+    { sub: 'tester', repo, iat: now, exp: now + 300, jti: 'policy-test' },
+    secret
+  );
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  github.getInstallationToken.mockResolvedValue('token');
+  github.getInstallationAccess.mockResolvedValue({ token: 'token', installationId: 123 });
+  github.createIssue.mockResolvedValue({
+    number: 42,
+    html_url: 'https://github.com/testowner/testrepo/issues/42',
+  });
+  github.isRepoPublic.mockResolvedValue(true);
+  github.uploadScreenshotAsAsset.mockResolvedValue('https://example.test/screenshot.png');
+  github.uploadAttachmentAsAsset.mockResolvedValue('https://example.test/report.pdf');
+});
+
+describe('repository policy installation checks', () => {
+  it.each([undefined, 'true'])('denies before GitHub or check auth (%s)', async required => {
+    const response = await api.request(
+      'http://bugdrop.localhost/check/blocked/repo',
+      {},
+      {
+        ...env,
+        ALLOWED_REPOSITORIES: 'approved/repo',
+        AUTH_TOKEN_SECRET: secret,
+        AUTH_TOKEN_REQUIRED_FOR_CHECK: required,
+      }
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'Repository is not allowed' });
+    expectNoGitHub();
+  });
+  it.each([undefined, '', ' \n ', '*', ' TESTOWNER/TESTREPO '])(
+    'allows compatible setting %j',
+    async config => {
+      const response = await api.request(
+        'http://bugdrop.localhost/check/testowner/testrepo',
+        {},
+        { ...env, ALLOWED_REPOSITORIES: config }
+      );
+      expect(response.status).toBe(200);
+      expect(github.getInstallationToken).toHaveBeenCalledWith(
+        expect.anything(),
+        'testowner',
+        'testrepo'
+      );
+    }
+  );
+  it('retains auth for an allowed installation check', async () => {
+    const response = await api.request(
+      'http://bugdrop.localhost/check/testowner/testrepo',
+      {},
+      {
+        ...env,
+        ALLOWED_REPOSITORIES: 'testowner/testrepo',
+        AUTH_TOKEN_SECRET: secret,
+        AUTH_TOKEN_REQUIRED_FOR_CHECK: 'true',
+      }
+    );
+    expect(response.status).toBe(401);
+    expectNoGitHub();
+  });
+});
+
+for (const [format, payload] of Object.entries({ legacy, structured })) {
+  describe(`${format} repository policy`, () => {
+    it('denies before all GitHub operations', async () => {
+      const response = await submit(payload, { ...env, ALLOWED_REPOSITORIES: 'approved/repo' });
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: 'Repository is not allowed' });
+      expectNoGitHub();
+    });
+    it.each([undefined, '', ' \n ', '*', ' TESTOWNER/TESTREPO '])(
+      'allows compatible setting %j',
+      async config => {
+        const response = await submit(payload, { ...env, ALLOWED_REPOSITORIES: config });
+        expect(response.status).toBe(200);
+        expect(github.getInstallationAccess).toHaveBeenCalledWith(
+          expect.anything(),
+          'testowner',
+          'testrepo'
+        );
+        expect(github.createIssue).toHaveBeenCalledOnce();
+      }
+    );
+    it.each([
+      ['valid', '0', 403, true],
+      ['missing', '0', 401, false],
+      ['invalid', '0', 401, false],
+      ['valid', '50', 429, false],
+    ] as const)(
+      'production auth %s, repo quota %s yields %i',
+      async (auth, count, status, repoWritten) => {
+        const kv = {
+          get: vi.fn(async (key: string) => (key.startsWith('repo:') ? count : '0')),
+          put: vi.fn().mockResolvedValue(undefined),
+        };
+        const token =
+          auth === 'valid'
+            ? await signedToken(payload.repo)
+            : auth === 'invalid'
+              ? 'invalid-token'
+              : undefined;
+        const response = await submit(
+          payload,
+          {
+            ...env,
+            ENVIRONMENT: 'production',
+            ALLOWED_REPOSITORIES: 'approved/repo',
+            AUTH_TOKEN_SECRET: secret,
+            RATE_LIMIT: kv as unknown as KVNamespace,
+          },
+          token
+        );
+        expect(response.status).toBe(status);
+        if (status === 403)
+          expect(await response.json()).toEqual({ error: 'Repository is not allowed' });
+        expect(kv.put.mock.calls.some(([key]) => key.startsWith('repo:'))).toBe(repoWritten);
+        expectNoGitHub();
+      }
+    );
+    it('allows an authenticated target without changing token claim spelling', async () => {
+      const response = await submit(
+        payload,
+        {
+          ...env,
+          ALLOWED_REPOSITORIES: 'TESTOWNER/TESTREPO',
+          AUTH_TOKEN_SECRET: secret,
+        },
+        await signedToken(payload.repo)
+      );
+      expect(response.status).toBe(200);
+      expect(github.createIssue).toHaveBeenCalledOnce();
+    });
+    it('preserves malformed repo validation', async () => {
+      const response = await submit(
+        { ...payload, repo: 'invalidformat' },
+        { ...env, ALLOWED_REPOSITORIES: 'approved/repo' }
+      );
+      expect(response.status).toBe(400);
+      expectNoGitHub();
+    });
+  });
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,6 +21,8 @@ binding = "ASSETS"
 
 # Environment variables
 [vars]
+# Optional exact repository allowlist (unset allows all installed repositories).
+# ALLOWED_REPOSITORIES = "example-org/app,example-org/feedback"
 ENVIRONMENT = "development"
 ALLOWED_ORIGINS = "*"  # "*" for dev, comma-separated URLs for production
 GITHUB_APP_NAME = "neonwatty-bugdrop"  # Your GitHub App's URL slug
@@ -62,6 +64,8 @@ workers_dev = true
 routes = []
 
 [env.preview.vars]
+# Optional exact repository allowlist (unset allows all installed repositories).
+# ALLOWED_REPOSITORIES = "example-org/app,example-org/feedback"
 ENVIRONMENT = "preview"
 ALLOWED_ORIGINS = "*"
 GITHUB_APP_NAME = "neonwatty-bugdrop"
@@ -101,6 +105,8 @@ directory = "public"
 binding = "ASSETS"
 
 [env.production.vars]
+# Optional exact repository allowlist (unset allows all installed repositories).
+# ALLOWED_REPOSITORIES = "example-org/app,example-org/feedback"
 ENVIRONMENT = "production"
 ALLOWED_ORIGINS = "*"
 GITHUB_APP_NAME = "neonwatty-bugdrop"


### PR DESCRIPTION
Adds an optional server-side `ALLOWED_REPOSITORIES` setting to restrict installation checks and both legacy and structured feedback destinations. A disallowed target returns `403` before GitHub lookup, uploads, or issue creation; successful token authentication cannot override the restriction.

A shared matcher uses trimmed, case-insensitive exact repository names with comma/newline separators. Unset, blank, and standalone `*` preserve unrestricted behavior. Existing validation, authentication, and quota precedence remain unchanged. Wrangler examples are commented, so this PR enables no production restriction and includes no personal-fork App routing or secrets.

### Verification

- `HUSKY=0 npm_config_foreground_scripts=false npm run validate`: lint, formatting, type checks, and 1,649 tests passed.
- `npm run verify:legacy-compat`: immutable legacy fixtures and bundle budget passed.
- 52 focused policy tests passed, including authenticated denials and real-client integration checks asserting no external requests.
- Independently removing each of the three guards caused the corresponding denial tests to fail; restoring the guards returned all focused tests to green.
- PR review toolkit's independent correctness, tests, silent-failure, contracts/types, and documentation reviews found no high-confidence issues.

### Review limitation

The native `codex review` baseline could not run: the installed CLI reports that its configured model requires a newer Codex version. The independent reviews completed against base `cbf871bd56a0c805a30f429843943b326dfce6b1`; this limitation is not a clean native-review result.

The validation environment variables avoid a reproduced pre-existing npm-pack/Husky race that contaminates JSON output during concurrent package tests. No repository code was changed to bypass that failure.
