### PR TITLE
Offer native viewport capture for iframe screenshot issues

### DIFF
--- a/e2e/default-flow-compatibility.spec.ts
+++ b/e2e/default-flow-compatibility.spec.ts
@@ -359,9 +359,7 @@ test.describe('paired default-flow screenshot compatibility oracle', () => {
 
         const widget = host(page);
         await expect(widget.locator('css=[data-action="viewport"]')).toBeVisible();
-        await expect(widget.locator('css=.bd-redaction-note')).toContainText(
-          'cannot apply automatic private-field masks'
-        );
+        await expect(widget.locator('css=.bd-redaction-note')).not.toBeAttached();
         await observe(page, trace, 'viewport-options-with-privacy-notice');
         await act(page, trace, 'capture-viewport', '[data-action="viewport"]');
         await expect(widget.locator('css=#annotation-canvas')).toBeVisible({ timeout: 10000 });

--- a/e2e/widget.spec.ts
+++ b/e2e/widget.spec.ts
@@ -5193,13 +5193,11 @@ test.describe('Screenshot Crash Prevention (#67)', () => {
 
     const viewportBtn = host.locator('css=[data-action="viewport"]');
     await expect(viewportBtn).toBeVisible();
-    await expect(viewportBtn).toHaveText('Capture Viewport');
+    await expect(viewportBtn).toHaveText('Screenshot Issues? Capture Viewport instead');
     await expect(host.locator('css=[data-action="capture"]')).not.toBeAttached();
     await expect(host.locator('css=[data-action="area"]')).not.toBeAttached();
     await expect(host.locator('css=p >> text=visible viewport')).toBeVisible();
-    await expect(host.locator('css=.bd-redaction-note')).toContainText(
-      'Browser viewport capture cannot apply automatic private-field masks'
-    );
+    await expect(host.locator('css=.bd-redaction-note')).not.toBeAttached();
 
     await viewportBtn.click();
 

--- a/src/widget/i18n.ts
+++ b/src/widget/i18n.ts
@@ -79,6 +79,7 @@ export interface WidgetStrings {
   pageTooComplexElementNote: string;
   fullPage: string;
   captureViewport: string;
+  viewportCaptureAlternative: string;
   selectArea: string;
   selectElement: string;
   skipScreenshot: string;

--- a/src/widget/locales/de.ts
+++ b/src/widget/locales/de.ts
@@ -86,6 +86,8 @@ export const de: WidgetStrings = {
   pageTooComplexElementNote:
     'Diese Seite ist zu komplex für eine vollständige Erfassung oder eine Bereichserfassung. Wählen Sie stattdessen ein bestimmtes Element aus.',
   fullPage: 'Ganze Seite',
+  viewportCaptureAlternative:
+    'Probleme mit Screenshots? Stattdessen den sichtbaren Bereich aufnehmen',
   captureViewport: 'Sichtbaren Bereich erfassen',
   selectArea: 'Bereich auswählen',
   selectElement: 'Element auswählen',

--- a/src/widget/locales/en.ts
+++ b/src/widget/locales/en.ts
@@ -81,6 +81,7 @@ export const en: WidgetStrings = {
   pageTooComplexElementNote:
     'This page is too complex for full-page or area capture. Select a specific element instead.',
   fullPage: 'Full Page',
+  viewportCaptureAlternative: 'Screenshot Issues? Capture Viewport instead',
   captureViewport: 'Capture Viewport',
   selectArea: 'Select Area',
   selectElement: 'Select Element',

--- a/src/widget/locales/nl.ts
+++ b/src/widget/locales/nl.ts
@@ -84,6 +84,8 @@ export const nl: WidgetStrings = {
   pageTooComplexElementNote:
     'Deze pagina is te complex om volledig of per gebied vast te leggen. Selecteer in plaats daarvan een specifiek element.',
   fullPage: 'Volledige pagina',
+  viewportCaptureAlternative:
+    'Problemen met screenshots? Leg in plaats daarvan het zichtbare gebied vast',
   captureViewport: 'Zichtbaar deel vastleggen',
   selectArea: 'Gebied selecteren',
   selectElement: 'Element selecteren',

--- a/src/widget/locales/pl.ts
+++ b/src/widget/locales/pl.ts
@@ -93,6 +93,7 @@ export const pl: WidgetStrings = {
   pageTooComplexElementNote:
     'Ta strona jest zbyt złożona, aby przechwycić całą stronę lub zaznaczony obszar. Zamiast tego zaznacz konkretny element.',
   fullPage: 'Cała strona',
+  viewportCaptureAlternative: 'Problemy ze zrzutem? Zamiast tego przechwyć widoczny obszar',
   captureViewport: 'Przechwyć widoczny obszar',
   selectArea: 'Zaznacz obszar',
   selectElement: 'Zaznacz element',

--- a/src/widget/screenshot-options.ts
+++ b/src/widget/screenshot-options.ts
@@ -20,13 +20,11 @@ export function showScreenshotOptions(
   opts?: { allowSkip?: boolean }
 ): Promise<ScreenshotChoice> {
   const fullPageDisabled = isFullPageDisabled();
-  const nativeViewportAvailable = fullPageDisabled && canCaptureViewportNatively();
+  const nativeViewportAvailable = canCaptureViewportNatively();
   const allowSkip = opts?.allowSkip !== false;
 
   let redactionNote = '';
-  if (nativeViewportAvailable) {
-    redactionNote = redactionNoteHtml(t().viewportRedactionWarning);
-  } else if (getRedactionCount() > 0) {
+  if (getRedactionCount() > 0) {
     redactionNote = redactionNoteHtml(t().redactionReviewNote);
   }
 
@@ -38,8 +36,6 @@ export function showScreenshotOptions(
     let primaryCaptureButton = '';
     if (!fullPageDisabled) {
       primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="capture">${escapeWidgetText(t().fullPage)}</button>`;
-    } else if (nativeViewportAvailable) {
-      primaryCaptureButton = `<button class="bd-btn bd-btn-primary" data-action="viewport">${escapeWidgetText(t().captureViewport)}</button>`;
     }
 
     const modal = createModal(
@@ -55,6 +51,7 @@ export function showScreenshotOptions(
           <button class="bd-btn bd-btn-secondary" data-action="element">${escapeWidgetText(t().selectElement)}</button>
           ${allowSkip ? `<button class="bd-btn bd-btn-quiet" data-action="skip">${escapeWidgetText(t().skipScreenshot)}</button>` : ''}
         </div>
+        ${nativeViewportAvailable ? `<p style="text-align: center; margin: 16px 0 0;"><a href="#" data-action="viewport" style="color: var(--bd-text-secondary); text-decoration: underline; text-underline-offset: 3px; font-size: 13px;">${escapeWidgetText(t().viewportCaptureAlternative)}</a></p>` : ''}
       `
     );
 
@@ -90,7 +87,8 @@ export function showScreenshotOptions(
       resolve({ kind: 'capture' });
     });
 
-    viewportBtn?.addEventListener('click', () => {
+    viewportBtn?.addEventListener('click', event => {
+      event.preventDefault();
       modal.remove();
       // beginViewportCapture must run synchronously inside the click handler to
       // preserve the user gesture required by getDisplayMedia. The in-flight

--- a/test/screenshotOptions.test.ts
+++ b/test/screenshotOptions.test.ts
@@ -75,6 +75,37 @@ describe('screenshot options', () => {
     await expect(result).resolves.toEqual({ kind: 'element' });
   });
 
+  it('hides the viewport link when native capture is unavailable on ordinary pages', async () => {
+    const root = document.createElement('div');
+    document.body.append(root);
+    const { showScreenshotOptions } = await import('../src/widget/screenshot-options');
+    const result = showScreenshotOptions(root);
+    expect(root.querySelector('[data-action="viewport"]')).toBeNull();
+    root.querySelector<HTMLElement>('[data-action="skip"]')?.click();
+    await expect(result).resolves.toEqual({ kind: 'skip' });
+  });
+
+  it('offers viewport capture alongside DOM capture on ordinary pages', async () => {
+    screenshotMocks.canCaptureViewportNatively.mockReturnValue(true);
+    const root = document.createElement('div');
+    document.body.append(root);
+    const { showScreenshotOptions } = await import('../src/widget/screenshot-options');
+    const result = showScreenshotOptions(root);
+    for (const action of ['capture', 'viewport', 'area', 'element']) {
+      expect(root.querySelector(`[data-action="${action}"]`)).not.toBeNull();
+    }
+    expect(root.textContent).not.toContain('cannot apply automatic private-field masks');
+    const viewport = root.querySelector('[data-action="viewport"]')!;
+    expect(viewport.tagName).toBe('A');
+    expect(viewport.textContent).toBe('Screenshot Issues? Capture Viewport instead');
+    expect(viewport.closest('.bd-actions')).toBeNull();
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+    viewport.dispatchEvent(click);
+    expect(click.defaultPrevented).toBe(true);
+    expect(screenshotMocks.beginViewportCapture).toHaveBeenCalledTimes(1);
+    expect(await result).toMatchObject({ kind: 'viewport' });
+  });
+
   it('starts viewport capture inside the click and returns the same delayed promise', async () => {
     screenshotMocks.isFullPageDisabled.mockReturnValue(true);
     screenshotMocks.canCaptureViewportNatively.mockReturnValue(true);
@@ -88,8 +119,14 @@ describe('screenshot options', () => {
     const { showScreenshotOptions } = await import('../src/widget/screenshot-options');
     const result = showScreenshotOptions(root);
 
-    expect(root.textContent).toContain('cannot apply automatic private-field masks');
-    root.querySelector<HTMLElement>('[data-action="viewport"]')?.click();
+    expect(root.textContent).not.toContain('cannot apply automatic private-field masks');
+    const viewport = root.querySelector('[data-action="viewport"]')!;
+    expect(viewport.tagName).toBe('A');
+    expect(viewport.textContent).toBe('Screenshot Issues? Capture Viewport instead');
+    expect(viewport.closest('.bd-actions')).toBeNull();
+    const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+    viewport.dispatchEvent(click);
+    expect(click.defaultPrevented).toBe(true);
     expect(screenshotMocks.beginViewportCapture).toHaveBeenCalledTimes(1);
     const choice = await result;
     expect(choice).toEqual({ kind: 'viewport', capture });


### PR DESCRIPTION
Native viewport capture is currently offered only when DOM complexity disables full-page capture. That leaves ordinary pages with sandboxed or cross-origin iframes offering DOM screenshots that omit the embedded content.

Expose the existing native capture path whenever canCaptureViewportNatively() succeeds, through a centered text link below the unchanged capture controls: “Screenshot Issues? Capture Viewport instead”. Keep browser capability checks, complex-page Full Page/Area restrictions, synchronous user activation, cancellation/cleanup, required-screenshot behavior and the privacy warning on annotation review. Remove the native-capture warning before the choice. Add translations for the link.

## Request context

A user reporting documentation issues could capture the host app but not its sandboxed document. They approved reusing native viewport capture, requested a text link rather than another button, and asked to show privacy guidance only on review. This PR changes no document sandbox or capture implementation. The same patch is being proposed separately to the WebEng self-hosted fork.

## Validation

Tested against upstream main d4099cc:
- Full unit suite: 1,649 passed; two pre-existing legacy fixture byte-count failures. Untouched d4099cc reproduces both (v1.1.0 and v1.53.1 fixture sizes).
- Chromium viewport/complex-page tests: 17 passed.
- Typecheck, widget build and make check passed.
- Regression tests cover ordinary-page native support/absence, anchor default prevention and synchronous capture, plus existing complex-page and rejection cases.
- Three parallel code, coverage and simplification reviews completed.

Native browser capture still requires the user's screen-share selection. Browser tests use the existing mocked display-media stream; physical mobile capture is not claimed.
